### PR TITLE
Fix spicetify data folder location for windows in instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Download the [dist branch](https://github.com/theRealPadster/name-that-tune/arch
 | **Platform**    | **Path**                               |
 |-----------------|----------------------------------------|
 | **Linux/macOS** | `~/.config/spicetify/CustomApps`       |
-| **Windows**     | `%userprofile%/.spicetify/CustomApps/` |
+| **Windows**     | `%localappdata%\spicetify\CustomApps` |
 
 After putting the name-that-tune folder into the correct custom apps folder, run the following command to enable it:
 ```


### PR DESCRIPTION
It appears that the location of the data folder in which you have to put the name-that-tune folder in on windows has changed. It is now in %localappdata%
Just felt the change was necessary, as I myself just now have wasted time trying to find the right location. Just wanna save other people the bother.