### PR TITLE
feat(logic): use `Spicetify.Player.data.item`

### DIFF
--- a/src/logic.ts
+++ b/src/logic.ts
@@ -52,7 +52,7 @@ const normalize = (str: string | undefined) => {
 
 export const checkGuess = (guess: string) => {
   console.log({
-    title: Spicetify.Player.data.track?.metadata?.title,
+    title: Spicetify.Player.data.item?.metadata?.title,
     guess,
   });
   // console.log({
@@ -61,7 +61,7 @@ export const checkGuess = (guess: string) => {
   // });
 
   const normalizedTitle = normalize(
-    Spicetify.Player.data.track?.metadata?.title,
+    Spicetify.Player.data.item?.metadata?.title,
   );
   const normalizedGuess = normalize(guess);
   console.log({ normalizedTitle, normalizedGuess });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -56,8 +56,8 @@ export const checkGuess = (guess: string) => {
     guess,
   });
   // console.log({
-  //   artist_name: Spicetify.Player.data.track.metadata.artist_name,
-  //   album_artist_name: Spicetify.Player.data.track.metadata.album_artist_name,
+  //   artist_name: Spicetify.Player.data.item.metadata.artist_name,
+  //   album_artist_name: Spicetify.Player.data.item.metadata.album_artist_name,
   // });
 
   const normalizedTitle = normalize(


### PR DESCRIPTION
track property is deprecated since Spicetify v2.23.0 https://github.com/spicetify/spicetify-cli/releases/tag/v2.23.0