### PR TITLE
fix: queue functions not working

### DIFF
--- a/src/logic.ts
+++ b/src/logic.ts
@@ -1,10 +1,14 @@
 // import FuzzySet from 'fuzzyset';
 import { diceCoefficient } from 'dice-coefficient';
 
-import { fetchAndPlay, shuffle, playList } from './shuffle+';
+import { fetchAndPlay, shuffle, Queue } from './shuffle+';
 import { getLocalStorageDataFromKey } from './Utils';
 import { STATS_KEY } from './constants';
 
+/**
+ * Set "now playing" info visiblity
+ * @param visible If we are enabling or disabling the now-playing info
+ */
 export const toggleNowPlaying = (visible: boolean) => {
   // visible = true;
   // Hide items that give away information while playing
@@ -89,7 +93,7 @@ export const initialize = (URIs?: string[]) => {
       return;
     }
 
-    playList(shuffle(URIs), null);
+    Queue(shuffle(URIs), null);
 
     // Spicetify.Player.playUri(URIs[0]);
     // Because it will start playing automatically


### PR DESCRIPTION
Updates functions from shuffle+ extension since the internal methods they use no longer exist. 

https://github.com/spicetify/spicetify-cli/commit/40adf67a6771d2811f17dfd734b68d0b225c4910 https://github.com/spicetify/spicetify-cli/commit/1ad0eba7bb6b6cfcd77670a167389a90f6d16c48

I just copied the functions I needed from the latest copy of shuffle+.js, and any other functions they relied on. There are a couple spots where I guessed at some changes that needed to be made, since I don't have the CONFIG object they do in the extension. 