### PR TITLE
feat: hide "next in queue" section

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,8 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import Game from './pages/Game';
 import Stats from './pages/Stats';
 
+import './css/app.global.scss';
+
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .use(LanguageDetector)

--- a/src/css/app.global.scss
+++ b/src/css/app.global.scss
@@ -1,5 +1,12 @@
 // When app is open...
 body.name-that-tune {
+
+  // "Next in queue" section on "now playing" sidebar
+  // (Always hide while app is active)
+  .main-nowPlayingView-queue {
+    display: none;
+  }
+
   // While guessing, hide items that give away information while playing
   &.name-that-tune--guessing {
     // The left side chunk with the title, artist, album art, etc.

--- a/src/css/app.global.scss
+++ b/src/css/app.global.scss
@@ -1,0 +1,20 @@
+// When app is open...
+body.name-that-tune {
+  // While guessing, hide items that give away information while playing
+  &.name-that-tune--guessing {
+    // The left side chunk with the title, artist, album art, etc.
+    .main-nowPlayingBar-left,
+    // Play/pause/next/previous/etc.
+    .player-controls__buttons,
+    // Now Playing sidebar
+    .main-nowPlayingView-content {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    // Disable playback bar interaction while playing
+    .playback-bar {
+      pointer-events: none;
+    }
+  }
+}

--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -1,4 +1,4 @@
-import { toggleNowPlaying } from '../logic';
+import { toggleIsGuessing } from '../logic';
 
 import i18n, { t } from 'i18next';
 import ca from '../locales/ca.json';
@@ -51,7 +51,12 @@ i18n
     console.log('History changed', data);
 
     const onApp = data.pathname.indexOf('name-that-tune') != -1;
-    toggleNowPlaying(!onApp);
+
+    // Add class to main container to indicate that the app is open
+    document.body.classList.toggle('name-that-tune', onApp);
+
+    // When app is first launched, it starts in guessing mode
+    toggleIsGuessing(onApp);
   });
 
   function sendToApp(URIs: string[]) {

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -6,31 +6,11 @@ import { getLocalStorageDataFromKey } from './Utils';
 import { STATS_KEY } from './constants';
 
 /**
- * Set "now playing" info visiblity
- * @param visible If we are enabling or disabling the now-playing info
+ * Set "is guessing" body class (controls element visibility/interactivity)
+ * @param guessing If we are enabling or disabling the "is guessing" class
  */
-export const toggleNowPlaying = (visible: boolean) => {
-  // visible = true;
-  // Hide items that give away information while playing
-  [
-    // The left side chunk with the title, artist, album art, etc.
-    document.querySelector<HTMLElement>('.main-nowPlayingBar-left'),
-    // Play/pause/next/previous/etc.
-    document.querySelector<HTMLElement>('.player-controls__buttons'),
-    // Now Playing sidebar
-    document.querySelector<HTMLElement>('.main-nowPlayingView-content'),
-  ].forEach((item) => {
-    if (item) {
-      item.style.opacity = visible ? '1' : '0';
-      item.style.pointerEvents = visible ? 'auto' : 'none';
-    }
-  });
-
-  // Disable playback bar interaction while playing
-  const playbackBar = document.querySelector<HTMLElement>('.playback-bar');
-  if (playbackBar) {
-    playbackBar.style.pointerEvents = visible ? 'auto' : 'none';
-  }
+export const toggleIsGuessing = (guessing: boolean) => {
+  document.body.classList.toggle('name-that-tune--guessing', guessing);
 };
 
 // TODO: potentially tweak this

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -6,7 +6,7 @@ import { TFunction } from 'i18next';
 import GuessItem from '../components/GuessItem';
 import Button from '../components/Button';
 
-import { initialize, toggleNowPlaying, checkGuess, saveStats, stageToTime } from '../logic';
+import { initialize, toggleIsGuessing, checkGuess, saveStats, stageToTime } from '../logic';
 import AudioManager from '../AudioManager';
 
 enum GameState {
@@ -99,7 +99,7 @@ class Game extends React.Component<
         this.audioManager.setEnd(0);
         Spicetify.Player.seek(0);
         Spicetify.Player.play();
-        toggleNowPlaying(true);
+        toggleIsGuessing(false);
       } else {
         this.audioManager.setEnd(stageToTime(this.state.stage));
       }
@@ -110,7 +110,7 @@ class Game extends React.Component<
     this.audioManager.setEnd(0);
     Spicetify.Player.seek(0);
     Spicetify.Player.play();
-    toggleNowPlaying(true);
+    toggleIsGuessing(false);
     saveStats(-1);
 
     this.setState({
@@ -119,7 +119,7 @@ class Game extends React.Component<
   };
 
   nextSong = () => {
-    toggleNowPlaying(false);
+    toggleIsGuessing(true);
     Spicetify.Player.next();
     Spicetify.Player.seek(0);
     Spicetify.Player.pause();


### PR DESCRIPTION
Hide the "next in queue" section in the now-playing sidebar. 
Also converts the app from using style attributes to using a css file for hiding and disabling interactivity on elements. 