### PR TITLE
feat: disable prev/next buttons while playing

### DIFF
--- a/src/css/app.global.scss
+++ b/src/css/app.global.scss
@@ -7,6 +7,15 @@ body.name-that-tune {
     display: none;
   }
 
+  // Disable prev/next buttons while playing
+  // (You need to use the in-game "next song" button, and I don't want people skipping
+  // backwards and having to replay the same songs to get back to where they were)
+  .main-skipForwardButton-button,
+  .main-skipBackButton-button {
+    opacity: 0.3;
+    pointer-events: none;
+  }
+
   // While guessing, hide items that give away information while playing
   &.name-that-tune--guessing {
     // The left side chunk with the title, artist, album art, etc.


### PR DESCRIPTION
You need to use the in-game "next song" button, and I don't want people skipping backwards and having to replay the same songs to get back to where they were. 

I think it's still fine to leave the play/pause enabled and let them scrub through the song though. I guess they could skip to the end and let the track finish to get to the next song, but they could also just use the media keys on their keyboard, so not a huge deal. 