### PR TITLE
fix: remaining crashes on current Spotify clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the [dist branch](https://github.com/theRealPadster/name-that-tune/arch
 | **Platform**    | **Path**                               |
 |-----------------|----------------------------------------|
 | **Linux/macOS** | `~/.config/spicetify/CustomApps`       |
-| **Windows**     | `%localappdata%\spicetify\CustomApps` |
+| **Windows**     | `%appdata%\spicetify\CustomApps`       |
 
 After putting the name-that-tune folder into the correct custom apps folder, run the following command to enable it:
 ```
@@ -43,7 +43,7 @@ spicetify apply
 - Right-click on any artist, playlist, album, etc. 
 - Click "play" to hear the first second of the track.
 - Making a guess adds one second of music playback. It will reveal the song when you get it right. 
-- (If you open it via the left-side navigation, it will just use the song you are currently playing.)
+- (If you open the app directly from the header bar, it will just use the song you are currently playing.)
 
 ## Translations
 I've added translations support! If you use Spotify in a non-English language and are getting the "Play Name That Tune" menu item etc in English, you can get your language added by either: 

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -41,7 +41,9 @@ class Game extends React.Component<
   audioManager: AudioManager;
   constructor(props) {
     super(props);
-    this.URIs = Spicetify.Platform.History.location.state.URIs;
+    // No state when opened from the sidebar rather than the context menu,
+    // in which case we just use whatever is currently playing
+    this.URIs = Spicetify.Platform.History.location.state?.URIs;
     this.audioManager = new AudioManager();
   }
 

--- a/src/shuffle+.ts
+++ b/src/shuffle+.ts
@@ -2,8 +2,6 @@
 /// <reference path="../../spicetify-cli/globals.d.ts" />
 /* eslint-enable */
 
-const { Type } = Spicetify.URI;
-
 export async function Queue(list, context = null) {
   const count = list.length;
 
@@ -157,6 +155,7 @@ async function fetchLikedTracks() {
 }
 
 async function fetchCollection(uriObj) {
+  const { Type } = Spicetify.URI;
   const { category, type } = uriObj;
   const { pathname } = Spicetify.Platform.History.location;
 
@@ -220,6 +219,7 @@ async function fetchShows(uri) {
 }
 
 export async function fetchAndPlay(rawUri) {
+  const { Type } = Spicetify.URI;
   let list,
     context,
     type,

--- a/src/types/css-modules.d.ts
+++ b/src/types/css-modules.d.ts
@@ -7,3 +7,6 @@ declare module '*.module.scss' {
   const classes: { [key: string]: string };
   export default classes;
 }
+
+// Side-effect imports only, so no exports to declare
+declare module '*.global.scss';


### PR DESCRIPTION
Follow-up to #190. That PR fixed the `react/jsx-runtime` crash that was killing the whole app on load, which then made two further crashes reachable — both pre-existing, both hidden behind it for months.

## Fixes

**Opening the app from the header bar crashed.** `Game`'s constructor read `Spicetify.Platform.History.location.state.URIs` unguarded. Only the right-click context menu pushes history state; opening the app directly leaves `location.state` undefined, so the constructor threw before rendering. With no URIs we fall through to whatever is currently playing, which is the intended behaviour.

**Right-clicking a playlist crashed.** `shuffle+.ts` destructured `const { Type } = Spicetify.URI` at module scope. The custom app bundle is evaluated while Spotify is still booting, before Spicetify has populated `URI.Type`, so `Type` was captured as `undefined` permanently and every `case Type.X` became `case undefined`. Upstream shuffle+ reads it inside its IIFE after a readiness guard; this does the equivalent by reading it at call time.

**`pnpm type-check` was failing.** TypeScript 6.0 errors on side-effect imports with no declaration, and `app.global.scss` matches neither existing `*.module.*` pattern. Scoped the new declaration to `*.global.scss` rather than `*.scss`, so missing or misspelled stylesheet imports are still caught — I verified a blanket `*.scss` silently swallows a bogus import path, and that the narrower pattern still preserves the typed default export for CSS modules.

**Docs.** The Windows install path is now `%appdata%\spicetify\CustomApps` (spicetify moved it from `%localappdata%`), and the usage note referred to the left-side navigation rather than the header bar.

## Testing

Verified against Spotify 1.2.94.583 / spicetify 2.44.0:

- App opens from the header bar without hitting the error boundary
- Right-clicking a playlist loads and queues; `PlaylistAPI.getContents` returned all 9997 tracks of a large playlist
- Stats page renders the chart
- `pnpm lint:ci`, `pnpm type-check` and `pnpm build:local` all pass

Not yet exercised: the gameplay loop itself (play / guess / skip / give up / next song) and `saveStats`.

Closes the remaining part of #160.