### PR TITLE
fix: resync shuffle+ with upstream

### DIFF
--- a/src/shuffle+.ts
+++ b/src/shuffle+.ts
@@ -2,6 +2,20 @@
 /// <reference path="../../spicetify-cli/globals.d.ts" />
 /* eslint-enable */
 
+// Adapted from the Shuffle+ extension in spicetify/cli:
+// https://github.com/spicetify/cli/blob/main/Extensions/shuffle+.js
+//
+// Last synced with upstream e95f802 (2026-07-04). To see what has changed since:
+//   git remote add spicetify https://github.com/spicetify/cli.git
+//   git fetch spicetify --filter=blob:none
+//   git log e95f802..spicetify/main -- 'Extensions/shuffle+.js'
+//
+// Intentional divergences from upstream: no CONFIG/settings UI or playbar
+// button, artists use singles and EPs only, and the artist GraphQL queries are
+// read live from Spicetify.GraphQL.Definitions rather than pinned to hardcoded
+// sha256 hashes (upstream pins them for older Spotify versions that no longer
+// ship those definitions).
+
 export async function Queue(list, context = null) {
   const count = list.length;
 
@@ -75,12 +89,15 @@ async function fetchPlaylistTracks(uri) {
 
 async function fetchAlbumTracks(uri, includeMetadata = false) {
   const { queryAlbumTracks } = Spicetify.GraphQL.Definitions;
-  const { data, errors } = await Spicetify.GraphQL.Request(queryAlbumTracks, { uri, offset: 0, limit: 500 });
+  // Limit 100 since GraphQL has a resource limit
+  const { data, errors } = await Spicetify.GraphQL.Request(queryAlbumTracks, { uri, offset: 0, limit: 100 });
 
   if (errors) throw errors[0].message;
   if (data.albumUnion.playability.playable === false) throw 'Album is not playable';
 
-  return data.albumUnion.tracks.items.filter(({ track }) => track.playability.playable).map(({ track }) => (includeMetadata ? track : track.uri));
+  return (data.albumUnion?.tracksV2 ?? data.albumUnion?.tracks ?? []).items
+    .filter(({ track }) => track.playability.playable)
+    .map(({ track }) => (includeMetadata ? track : track.uri));
 }
 
 async function scanForTracksFromAlbums(res, artistName) {
@@ -149,9 +166,9 @@ async function fetchLocalTracks() {
 }
 
 async function fetchLikedTracks() {
-  const res = await Spicetify.CosmosAsync.get('sp://core-collection/unstable/@/list/tracks/all?responseFormat=protobufJson');
+  const res = await Spicetify.Platform.LibraryAPI.getTracks({ limit: 9999999 });
 
-  return res.item.filter(track => track.trackMetadata.playable).map(track => track.trackMetadata.link);
+  return res.items.filter(track => track.isPlayable).map(track => track.uri);
 }
 
 async function fetchCollection(uriObj) {
@@ -181,30 +198,30 @@ async function fetchCollection(uriObj) {
 
 function searchFolder(rows, uri) {
   for (const r of rows) {
-    if (r.type !== 'folder' || !r.rows) continue;
+    if (r.type !== 'folder' || !r.items) continue;
 
-    if (r.link === uri) return r;
+    if (r.uri === uri) return r;
 
-    const found = searchFolder(r.rows, uri);
+    const found = searchFolder(r.items, uri);
     if (found) return found;
   }
 }
 
 async function fetchFolderTracks(uri) {
-  const res = await Spicetify.CosmosAsync.get(`sp://core-playlist/v1/rootlist`, {
-    policy: { folder: { rows: true, link: true } },
-  });
+  const res = await Spicetify.Platform.RootlistAPI.getContents();
 
-  const requestFolder = searchFolder(res.rows, uri);
+  const requestFolder = searchFolder(res.items, uri);
   if (!requestFolder) throw 'Cannot find folder';
 
   const requestPlaylists: unknown[] = [];
   async function fetchNested(folder) {
-    if (!folder.rows) return;
+    if (!folder.items) return;
 
-    for (const i of folder.rows) {
-      if (i.type === 'playlist') requestPlaylists.push(await fetchPlaylistTracks(i.link.split(':')[2]));
-      else if (i.type === 'folder') await fetchNested(i);
+    for (const i of folder.items) {
+      if (i.type === 'playlist') {
+        const uriObj = Spicetify.URI.fromString(i.uri);
+        requestPlaylists.push(await fetchPlaylistTracks((uriObj as { _base62Id?: string })._base62Id ?? uriObj.id));
+      } else if (i.type === 'folder') await fetchNested(i);
     }
   }
 
@@ -264,7 +281,7 @@ export async function fetchAndPlay(rawUri) {
       }
 
       context = rawUri;
-      if (type === 'folder' || type === 'collection') {
+      if (type === 'folder' || type === 'collection' || type === 'local') {
         context = null;
       }
     }


### PR DESCRIPTION
`src/shuffle+.ts` is a fork of the Shuffle+ extension in `spicetify/cli`, last synced around 2023-12. Four compatibility fixes have landed upstream since, and all four are things Spotify actually changed — right-clicking an **album**, **artist**, **folder** or **Liked Songs** is currently broken. #190 already ported the fifth (playlists).

## Changes

**Albums** — `data.albumUnion.tracks` no longer exists. Read `tracksV2` with a fallback, and drop the GraphQL limit 500 → 100 to stay under the resource cap. Upstream `631146a`, `8ec27dd`.

**Artists** — no code change needed, but this was broken by the same bug: `fetchArtistTracks` → `scanForTracksFromAlbums` → `fetchAlbumTracks`.

**Liked Songs** — `sp://core-collection/unstable/@/list/tracks/all` → `Spicetify.Platform.LibraryAPI.getTracks({ limit })`, with fields moving from `res.item[].trackMetadata.{playable,link}` to `res.items[].{isPlayable,uri}`. Upstream `e95f802`.

**Folders** — `sp://core-playlist/v1/rootlist` → `Spicetify.Platform.RootlistAPI.getContents()`. The response shape changed throughout, so `searchFolder` now matches on `r.uri` and recurses `r.items` (was `r.link`/`r.rows`), and nested playlist IDs come from `Spicetify.URI.fromString(i.uri)` instead of `i.link.split(':')[2]`. Upstream `3dd3c2f`.

**Local tracks** — reset the playback context for `local` as well as `folder`/`collection`. Upstream `4635543`.

**Header note** — records the upstream source, the synced-to commit, the `git log` incantation to see what has changed since, and the intentional divergences. This drifted 2.5 years mostly because nothing recorded where the fork point was.

## Deliberately not ported

Upstream pins `queryArtistOverview` and `queryArtistDiscographyAll` to hardcoded `sha256Hash` values, because Spotify dropped them from the client bundle in some versions. Both are present in `Spicetify.GraphQL.Definitions` on 1.2.94, so we keep reading them live rather than freezing a server-side contract we can't renegotiate.

Also skipped: the shuffle-the-queue feature (`4950982`) and the biome formatting passes.

## Verified against Spotify 1.2.94.583 / spicetify 2.44.0

Both the API contracts and the end-to-end flows were checked on a real client.

**API shapes, in devtools:**

- Album query returns `hasTracksV2: true, hasLegacyTracks: false` — the legacy field is gone entirely, confirming the old code was throwing rather than merely deprecated
- `RootlistAPI.getContents()` returns 8 folders, each with `uri` and populated nested `items`
- `LibraryAPI.getTracks` returns `items` carrying `uri` and `isPlayable`
- Both artist GraphQL definitions resolve and return releases

**End-to-end, via the right-click menu:**

| Target | Result |
|---|---|
| Album | Loads and plays |
| Artist | Loads |
| Folder (x2) | Loads, plausible track counts across nested playlists |
| Playlist | Loads, no regression from #190 |
| Multi-select tracks | Loads, no regression |
| Liked Songs | `fetchLikedTracks` body verified in devtools; the `fetchCollection` dispatch to it is untouched by this PR and was not separately exercised |

No `console.error` output during any of it — `fetchAndPlay` catches and logs everything, so a bad response shape or a failed GraphQL request would have surfaced.

`pnpm lint:ci`, `pnpm type-check` and `pnpm build:local` all pass.

## Unrelated bug found while testing

Right-clicking an item **while already on the Name That Tune page** does nothing: the extension resolves the URI and calls `History.push`, but pushing the same pathname doesn't register, so `Game`'s constructor — the only place `state.URIs` is read — never re-runs. Navigating away first works fine.

This is pre-existing and out of scope here, but it's worth knowing when testing this PR: navigate to Home or a playlist between each right-click, or the fetch you think you are exercising never runs.

Note also that folders with many nested playlists fetch sequentially, so expect a few seconds before the toast on large ones.
