### PR TITLE
fix: allow starting a new game from the game page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -46,15 +46,41 @@ i18n
     },
   });
 
-class App extends React.Component {
+type HistoryLocation = {
+  pathname: string;
+  key?: string;
+  state?: { URIs?: string[] };
+};
+
+class App extends React.Component<Record<string, never>, { location: HistoryLocation }> {
+  state: { location: HistoryLocation } = {
+    location: Spicetify.Platform.History.location,
+  };
+
+  unlisten?: () => void;
+
+  // Spotify's router doesn't necessarily re-render us on its own, so listen
+  // ourselves to make sure relaunching the game picks up the new URIs
+  componentDidMount() {
+    this.unlisten = Spicetify.Platform.History.listen((location: HistoryLocation) => {
+      this.setState({ location });
+    });
+  }
+
+  componentWillUnmount() {
+    this.unlisten?.();
+  }
+
   render() {
-    const { location } = Spicetify.Platform.History;
+    const { location } = this.state;
     // If page state set to stats, render it
     if (location.pathname === '/name-that-tune/stats') {
       return <Stats t={t} />;
     } // Otherwise, render the main Game
     else {
-      return <Game t={t} />;
+      // Keyed on the history entry so that relaunching from the game page
+      // remounts with the new URIs rather than reusing the running game
+      return <Game key={location.key} URIs={location.state?.URIs} t={t} />;
     }
   }
 }

--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -88,6 +88,9 @@ i18n
 
     Spicetify.Platform.History.push({
       pathname: '/name-that-tune',
+      // Pushing an identical location is a no-op, so without something unique
+      // here you can't start a new game while already on the game page
+      search: `?t=${Date.now()}`,
       state: {
         URIs,
       },

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -41,9 +41,9 @@ class Game extends React.Component<
   audioManager: AudioManager;
   constructor(props) {
     super(props);
-    // No state when opened from the sidebar rather than the context menu,
+    // Undefined when opened from the header bar rather than the context menu,
     // in which case we just use whatever is currently playing
-    this.URIs = Spicetify.Platform.History.location.state?.URIs;
+    this.URIs = props.URIs;
     this.audioManager = new AudioManager();
   }
 


### PR DESCRIPTION
Right-clicking anything while already on the Name That Tune page did nothing. Found while testing #195 — three folder tests appeared to fail before it turned out they had never run.

## Two faults, stacked

**Spotify's history drops identical pushes.** `sendToApp` resolved the URI and called `History.push({ pathname: '/name-that-tune', state: { URIs } })`, but when you're already on that pathname the push is a complete no-op. Confirmed in devtools: the listener never fires and `location.key` doesn't change. Adding a unique `search` makes it register.

**And nothing remounted even once it did.** `App.render` read `Spicetify.Platform.History.location` directly, so it only re-rendered if Spotify's router chose to re-render it — and a search-only change didn't. Even then, `<Game>` at the same position with the same type gets reused by React, and `Game` read `state.URIs` in its **constructor**, so new URIs were never picked up.

Fixing either alone leaves it broken.

## Changes

- `extension.tsx` — add `?t=${Date.now()}` to the push so each launch is a distinct location. Invisible to users; Spotify has no address bar.
- `app.tsx` — subscribe to `History.listen` and hold the location in state, so re-rendering doesn't depend on router behaviour. Key `<Game>` on `location.key` so it genuinely remounts.
- `Game.tsx` — take URIs from `props.URIs` instead of reaching into history. The props type **already declared `URIs?: string[]`** and never used it, so this restores the intended design and removes another constructor-time read of `location.state` — the same pattern behind the header-bar crash fixed in #194.

## Note on the token

A content-derived key (hashing the URIs) was considered, so relaunching the same playlist wouldn't restart an in-progress game. Not done here, deliberately: it would implement that policy as a side effect of Spotify's dedupe quirk rather than stating it, it would silently do nothing on a re-click — the exact confusing behaviour this PR removes — and it would make a deliberate reshuffle of the same source unexpressible, since `initialize()` shuffles on every launch.

If we want "don't restart the same game", it should be an explicit check with a toast explaining why nothing happened. Worth its own change.

## Testing

Verified on Spotify 1.2.94.583 / spicetify 2.44.0.

**Diagnosis, before writing anything** — a plain push neither fires the history listener nor changes `location.key`; the same push with a unique `search` does both. That's what established it was two separate faults rather than one.

**The fix itself** — right-clicking playlist A, then playlist B **without leaving the game page**, now produces two distinct mounts:

```
History changed {pathname: '/name-that-tune', search: '?t=1785630569973'}
App mounted, URIs: ['spotify:playlist:7Ajs…']

History changed {pathname: '/name-that-tune', search: '?t=1785630582769'}
App mounted, URIs: ['spotify:playlist:757H…']
```

No navigation in between. Previously the second right-click logged `Sending URIs:` and then nothing at all.

**Regressions:**

| Check | Result |
|---|---|
| First launch from Home | Mounts with URIs, playback starts |
| App restored on the game page at startup, no URIs | `App mounted, URIs: undefined`, no crash — the `props.URIs` path |
| Stats page from a game | Renders; `totalGames: 283` unchanged |
| Back navigation | Walks back through prior games, each remounting with its own URIs |

`pnpm lint:ci`, `pnpm type-check` and `pnpm build:local` all pass.

**Behaviour worth knowing:** each launch is now its own history entry, so going back re-runs `initialize()` for that entry — it reshuffles and re-queues from the same source rather than literally resuming the earlier game.
