### PR TITLE
fix: restore the info hiding broken by Spotify 1.2.94

### DIFF
--- a/src/css/app.global.scss
+++ b/src/css/app.global.scss
@@ -1,3 +1,14 @@
+// These selectors are Spotify's own, so they rot when Spotify restructures its
+// UI - and they fail silently, by showing the player again rather than erroring.
+// To find what has been renamed, run this in devtools with a game in progress
+// and the "now playing" sidebar open. Anything reporting 0 needs a new selector:
+//
+//   ['.main-nowPlayingBar-left', '.player-controls__buttons',
+//    '.main-nowPlayingView-mainContainer', '.main-nowPlayingView-queue',
+//    '.playback-bar', '[data-testid="control-button-skip-back"]',
+//    '[data-testid="control-button-skip-forward"]']
+//     .forEach(s => console.log(document.querySelectorAll(s).length, s));
+
 // When app is open...
 body.name-that-tune {
 
@@ -10,8 +21,9 @@ body.name-that-tune {
   // Disable prev/next buttons while playing
   // (You need to use the in-game "next song" button, and I don't want people skipping
   // backwards and having to replay the same songs to get back to where they were)
-  .main-skipForwardButton-button,
-  .main-skipBackButton-button {
+  // Spotify no longer puts a mapped class on these, so go by its test ids
+  [data-testid='control-button-skip-back'],
+  [data-testid='control-button-skip-forward'] {
     opacity: 0.3;
     pointer-events: none;
   }
@@ -22,8 +34,10 @@ body.name-that-tune {
     .main-nowPlayingBar-left,
     // Play/pause/next/previous/etc.
     .player-controls__buttons,
-    // Now Playing sidebar
-    .main-nowPlayingView-content {
+    // Now Playing sidebar. Everything below its header: cover art, track info,
+    // about the artist, credits, tour dates and merch all name the artist.
+    // Leaving the header alone keeps the close button usable.
+    .main-nowPlayingView-mainContainer {
       opacity: 0;
       pointer-events: none;
     }

--- a/src/css/app.global.scss
+++ b/src/css/app.global.scss
@@ -4,7 +4,8 @@
 // and the "now playing" sidebar open. Anything reporting 0 needs a new selector:
 //
 //   ['.main-nowPlayingBar-left', '.player-controls__buttons',
-//    '.main-nowPlayingView-mainContainer', '.main-nowPlayingView-queue',
+//    '.main-nowPlayingView-mainContainer', '.main-nowPlayingView-headerText',
+//    '.main-nowPlayingView-queue',
 //    '.playback-bar', '[data-testid="control-button-skip-back"]',
 //    '[data-testid="control-button-skip-forward"]']
 //     .forEach(s => console.log(document.querySelectorAll(s).length, s));
@@ -36,8 +37,11 @@ body.name-that-tune {
     .player-controls__buttons,
     // Now Playing sidebar. Everything below its header: cover art, track info,
     // about the artist, credits, tour dates and merch all name the artist.
-    // Leaving the header alone keeps the close button usable.
-    .main-nowPlayingView-mainContainer {
+    .main-nowPlayingView-mainContainer,
+    // The sidebar header shows the playback context, which is the album title
+    // when playing an album. Its buttons live in a sibling container, so the
+    // panel can still be closed.
+    .main-nowPlayingView-headerText {
       opacity: 0;
       pointer-events: none;
     }


### PR DESCRIPTION
The whole point of the game is not seeing the song, and on Spotify 1.2.94 three of the seven hiding selectors had silently stopped matching. The failure mode is invisible: nothing errors, the answer just shows.

Found by probing the live DOM with a game in progress:

| Selector | Matches |
|---|---|
| `.main-nowPlayingView-content` | **0** |
| `.main-skipForwardButton-button` | **0** |
| `.main-skipBackButton-button` | **0** |
| `.main-nowPlayingBar-left` | 1 |
| `.player-controls__buttons` | 1 |
| `.main-nowPlayingView-queue` | 1 |
| `.playback-bar` | 1 |

## The sidebar

`-content` no longer exists. A DOM snapshot shows the panel is now:

```
aside.NowPlayingView
├── .main-nowPlayingView-headerContainer     ← playlist name, close button
└── .main-nowPlayingView-mainContainer       ← everything that leaks
    └── .main-nowPlayingView-panel
        ├── cover art + .main-nowPlayingView-trackInfo
        ├── .main-nowPlayingView-aboutArtist
        ├── .main-nowPlayingView-credits
        ├── on-tour section
        └── merch section
```

Also hidden: `.main-nowPlayingView-headerText`. It shows the **playback context** — harmless for a playlist game you chose yourself, but it's the album title when playing an album, which gives away the artist and narrows the song to a handful. The header's buttons live in a sibling container, so the panel is still closeable.

It wasn't just the title leaking — the artist name appeared five separate ways (track info, about-artist, credits, tour dates, merch). Hiding `mainContainer` covers all of them while leaving the header intact so the panel stays closeable.

## The skip buttons

Spotify no longer applies a mapped class; the buttons are still there as `data-testid="control-button-skip-back"` / `"control-button-skip-forward"`. Test ids are a more stable hook than the hashed classes anyway.

This one only bites *after* a reveal — while guessing, `.player-controls__buttons` already hides them — but that's exactly when skipping desyncs the queue from the game.

## Known limitation

Not fixable in CSS: Spotify keeps a live region announcing the track, and the now-playing bar carries an `aria-label` with it:

```html
<span aria-live="polite" role="status">Now playing: Wake Up, Mr. Crow by Switchfoot</span>
```

Screen-reader users are told the answer regardless.

## Also added

A comment at the top of the file with a copy-pasteable probe listing every selector, so the next time Spotify restructures its UI this is a five-minute check rather than a discovery.

## Testing

Verified by hand on Spotify 1.2.94.583: with a game in progress and the sidebar open, the cover art, track info, about-artist, credits, tour dates and merch are all hidden, and the panel still closes.

Compiled output checked — every selector present in the built `style.css`. `pnpm lint:ci`, `pnpm type-check` and `pnpm build:local` pass.

Reopening the sidebar after closing it is via the `Now playing view` button at the bottom right of the player bar; `.main-nowPlayingBar-right` is deliberately left untouched so that stays reachable.
