### PR TITLE
chore: track Claude config and add a Spotify debug-port skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A [Spicetify](https://spicetify.app) custom app that turns the Spotify desktop client into a Heardle-style
+"guess the song" game. It runs *inside* the Spotify client, so `Spicetify.*` globals (Player, Platform,
+ContextMenu, URI, CosmosAsync, GraphQL, React) are the entire runtime API surface — there is no server,
+no bundled React, and no DOM outside of Spotify's own.
+
+Note the README: the project is no longer in active development.
+
+## Commands
+
+pnpm only (`engines` blocks npm/yarn), Node >= 24 (`.nvmrc`).
+
+| Command | What it does |
+|---|---|
+| `pnpm build` | Builds straight into your live Spicetify `CustomApps/name-that-tune` folder (resolved via `spicetify -c`). Run `spicetify apply` after. |
+| `pnpm watch` | Same target, rebuild on change. Normal dev loop. |
+| `pnpm build:local` | Minified build into `./dist` — what CI runs. `dist/` is gitignored on `main`. |
+| `pnpm lint` / `pnpm lint:ci` | ESLint with `--fix` / without. |
+| `pnpm type-check` | `tsc --noEmit`. **Not run in CI** — run it manually before finishing work. |
+| `pnpm update-types` | Re-downloads `src/types/spicetify.d.ts` from spicetify-cli upstream. |
+
+There are no tests. Verification = `pnpm lint:ci && pnpm type-check && pnpm build:local`.
+
+CI: `lint.yml` (push/PR to main), `build.yml` (PR). `push-dist.yml` builds on every push to `main` and
+commits the output to the `dist` branch — that branch is what users download, so `main` is effectively
+released on merge.
+
+## Architecture
+
+### Two independent bundles
+
+`spicetify-creator` (esbuild) emits two separate things from `src/`:
+
+1. **The custom app** — entry `src/app.tsx`, mounted by Spotify when the user navigates to
+   `/name-that-tune`. `src/settings.json` is the app manifest (`nameId` determines both the output
+   folder name and the route).
+2. **The extension** — every file in `src/extensions/` becomes its own bundle, loaded at Spotify
+   startup regardless of route. `extension.tsx` polls until `Spicetify.Platform`/`ContextMenu`/`URI`
+   exist, then registers the right-click menu entry and a `History.listen` handler.
+
+They share no runtime state. This is why i18n init is **duplicated verbatim** in `src/app.tsx` and
+`src/extensions/extension.tsx` — adding a locale means editing the `resources` map in *both*, plus
+dropping the JSON in `src/locales/`.
+
+`react` / `react-dom` are marked external and rewritten to `Spicetify.React` / `Spicetify.ReactDOM`.
+Everything else is bundled, which is why all deps live in `devDependencies`.
+
+### Routing
+
+Hand-rolled: `App.render()` reads `Spicetify.Platform.History.location.pathname` and returns `<Stats>`
+for `/name-that-tune/stats`, `<Game>` otherwise. Navigation is `History.push({ pathname, state })`.
+
+### Data flow for a game
+
+1. Context menu (extension) → `sendToApp(URIs)` → `History.push('/name-that-tune', { state: { URIs } })`.
+2. `Game`'s constructor reads `Spicetify.Platform.History.location.state.URIs` — this is the only
+   channel between extension and app.
+3. `logic.initialize(URIs)` → `shuffle+.ts`, which resolves a URI to a track list depending on its type
+   (playlist/album/artist/folder/collection/show, each via a different Cosmos or GraphQL call) and
+   then pushes that list onto Spotify's queue via the private
+   `Spicetify.Platform.PlayerAPI._queue._client.setQueue`. `shuffle+.ts` is adapted from the
+   Shuffle+ extension and leans on undocumented internals; expect it to break on Spotify updates.
+
+### Clipping playback
+
+`AudioManager` is the mechanism that only lets you hear the first N seconds: it subscribes to the
+player's `onprogress` event and, once progress exceeds `end` seconds, calls `pause()` + `skipBack()`.
+`end` comes from `stageToTime(stage) = 1 + 0.5(stage + stage²)` (1s, 2s, 4s, 7s, 11s, 16s — Heardle's
+curve). Setting `end` to `0` disables clipping, which is how winning/giving up reveals the full song.
+
+### Hiding the answer
+
+Two body classes drive all information-hiding, and both bundles set them:
+
+- `body.name-that-tune` — app is open (set by the extension's `History.listen`).
+- `body.name-that-tune--guessing` — a round is in progress (`logic.toggleIsGuessing`, called from both
+  the extension on navigation and from `Game` on win/give-up/next).
+
+`src/css/app.global.scss` uses them to hide the now-playing bar, queue, and skip buttons. It targets
+Spotify's own internal class names (`.main-nowPlayingBar-left`, `.player-controls__buttons`, …), which
+are unversioned and change between Spotify releases — this is the most fragile part of the app.
+Component styling uses SCSS modules (`*.module.scss`) instead, and Spicetify CSS vars (`--spice-text`).
+
+### Guess matching
+
+`logic.normalize()` strips parentheticals, everything after ` - `, diacritics, and all non-alphanumerics
+(with explicit ranges kept for Cyrillic/Polish/Arabic/Hebrew), then `diceCoefficient` > `0.8` counts as
+correct.
+
+### Stats
+
+Written to `localStorage` under `name-that-tune:stats` as `{ [stage]: count }`, where `-1` means
+"gave up". `Stats.tsx` buckets stage > 5 into ">16s" and renders a chart.js horizontal bar chart.
+
+## Conventions
+
+- `src/types/spicetify.d.ts` is generated (`pnpm update-types`) and ESLint-ignored — never hand-edit it.
+- Pages/components are React **class** components with local state; there is no store.
+- ESLint enforces 2-space indent, single quotes, semicolons, trailing commas on multiline. `switch`
+  cases are *not* indented (see `shuffle+.ts`) — that's the configured `indent` rule's behaviour, don't
+  "fix" it.
+- Translation strings use i18next interpolation and `$t(appName)` references; plurals use the
+  `_one` / `_other` suffixes.
+- Dependabot runs monthly and ignores patch updates; most commits on `main` are those bumps.

--- a/.claude/skills/spicetify-drive/SKILL.md
+++ b/.claude/skills/spicetify-drive/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: spicetify-drive
+description: Attach to the running Spotify desktop client over the Chrome DevTools Protocol to inspect or drive it — read Spicetify internals, run real GraphQL requests, measure computed styles and geometry, dispatch real key/mouse/wheel input, and take screenshots. Also covers the build → apply → relaunch → attach loop for testing a Spicetify custom app or extension in the real client. Use when a claim about Spotify's runtime needs verifying rather than guessing (does this GraphQL definition exist, what shape does it return, which element actually receives this click, does this scroll chain), or when the user asks to run, test, or screenshot a Spicetify app in Spotify.
+---
+
+# Driving Spotify over the debug port
+
+Spotify is Chromium, so it speaks the DevTools Protocol. That turns guesses about
+its private internals into measurements. Reach for this whenever the honest answer
+would otherwise be "probably" — undocumented GraphQL definitions, Spotify's own
+class names, computed styles, hit testing, scroll behaviour.
+
+## Preconditions
+
+The endpoint only exists if devtools are enabled:
+
+```bash
+grep always_enable_devtools "$(spicetify -c)"   # want: = 1
+```
+
+If it is `0`: `spicetify enable-devtools`, then relaunch Spotify.
+
+**The port is 8088, not the usual 9222.** There is no `--remote-debugging-port`
+flag on the process, so do not go looking for one.
+
+```bash
+curl -s http://127.0.0.1:8088/json | python3 -m json.tool   # find the xpui target
+```
+
+## Two modes, very different cost
+
+### Inspect — cheap, do this freely
+
+Attaching changes nothing. No build, no restart, no disruption. Use it constantly.
+
+```bash
+node .claude/skills/spicetify-drive/driver.mjs ./probe.mjs
+```
+
+```js
+// probe.mjs
+export default async (d) => {
+  console.log(await d.eval(`Object.keys(Spicetify.GraphQL.Definitions).filter(k => /search/i.test(k))`));
+};
+```
+
+Good for: does a definition exist; what does a GraphQL call actually return; what
+are the computed styles; what does `document.elementFromPoint` return at these
+coordinates; what is in the console.
+
+Note it inspects **the installed build**, which may be older than the working
+tree. Check before drawing conclusions:
+
+```bash
+ls -la "$(dirname "$(spicetify -c)")/CustomApps/<app>/"
+```
+
+### Drive — expensive, confirm with the user first
+
+Testing working-tree changes needs the code inside Spotify's xpui, and there is no
+lighter path than a full apply. This **restarts Spotify** and **disturbs playback**.
+Get explicit agreement before running it.
+
+```bash
+pnpm build                       # into the live CustomApps folder
+spicetify apply                  # copies into Spotify.app, then QUITS Spotify
+open -a Spotify                  # apply does NOT relaunch it
+sleep 14                         # let xpui boot before attaching
+```
+
+## Side effects, and putting things back
+
+Driving a real client leaves marks. Save state first, restore after, and tell the
+user what moved:
+
+```js
+// before
+const before = await d.eval(`({
+  pathname: Spicetify.Platform.History.location.pathname,
+  context: Spicetify.Player.data?.context?.uri,
+})`);
+
+// after
+await d.eval(`Spicetify.Platform.History.push({ pathname: ${JSON.stringify(before.pathname)} })`);
+await d.eval(`Spicetify.Player.pause()`);
+```
+
+Playback position and the current track generally cannot be restored — say so
+rather than implying it was. Watch for apps that persist to `localStorage`
+(name-that-tune writes `name-that-tune:stats`); a test run can leave junk there.
+
+To try a **light theme** without touching the user's actual theme, override the
+Spicetify vars inline and remove them afterwards:
+
+```js
+await d.eval(`(() => { const s = document.documentElement.style;
+  s.setProperty('--spice-main', '#ffffff'); s.setProperty('--spice-text', '#121212'); })()`);
+// ... screenshot ...
+await d.eval(`['--spice-main','--spice-text'].forEach(p => document.documentElement.style.removeProperty(p))`);
+```
+
+## Input gotchas
+
+Both of these cost real debugging time. They look like app bugs and are not.
+
+- **Printable characters must be a lone `char` event.** Pairing `char` with a
+  `keyDown` that also carries `text` types everything twice — `bohem` arrives as
+  `bboohheemm`. `d.type()` handles this.
+- **Enter needs a real `keyDown` with `text: '\r'`.** A `rawKeyDown` suppresses the
+  keypress, so Chromium never runs a form's default submit and the Enter appears
+  to do nothing. `d.key('Enter', 13)` handles this.
+
+Use real dispatched events, not `el.value = x` — Spotify's UI is React, and
+assigning to `value` does not drive a controlled input.
+
+Beware selectors that also match Spotify's own chrome. `input[role=combobox]`
+matches the main search bar; scope to something app-specific.
+
+## Driver API
+
+`driver.mjs` needs no dependencies (Node's built-in `WebSocket`). Your script
+default-exports an async function taking `d`:
+
+| | |
+|---|---|
+| `d.eval(expr)` | evaluate in the page, by value, awaits promises |
+| `d.waitFor(expr, {timeout})` | poll until truthy |
+| `d.type(str, delay?)` | printable text as real key events |
+| `d.key(name, keyCode)` | ArrowUp 38, ArrowDown 40, Enter 13, Escape 27, Tab 9 |
+| `d.clear(selector)` | empty a React-controlled input |
+| `d.click(selector)` / `d.clickText(text, tag?)` | real mouse events |
+| `d.wheel(selector, deltaY)` | for overscroll / scroll-chaining checks |
+| `d.shot(path)` | PNG screenshot |
+| `d.consoleLines` | captured console output |
+| `d.send(method, params)` | any raw CDP call |
+
+## Worked checks
+
+**Does a GraphQL definition exist, and what does it return?** Definitions are
+persisted queries (`{name, operation, sha256Hash, value: null}`) — there is no
+local AST to read, so run it and inspect the response. The server validates
+variables against the stored operation, so a wrong variable set gives
+`HttpResponseError`; different operations take different variables.
+
+```js
+const res = await d.eval(`Spicetify.GraphQL.Request(
+  Spicetify.GraphQL.Definitions.searchSuggestions, { query: 'test', limit: 5 })`);
+```
+
+**Which element really receives a click?** Settles overlay questions that reading
+CSS cannot.
+
+```js
+await d.eval(`(() => {
+  const r = document.querySelector('button').getBoundingClientRect();
+  const hit = document.elementFromPoint(r.x + r.width/2, r.y + r.height/2);
+  return hit.tagName + '.' + hit.className;
+})()`);
+```
+
+**Does scrolling chain to the page?** Wheel past the end and watch every
+scrollable ancestor — if one moves off 0, the inner element needs
+`overscroll-behavior: contain`.
+
+## Reporting
+
+Quote the measurement, not the impression: "ancestor `scrollTop` went 0 → 12"
+beats "it seems to scroll the page". When a fix is verified, show before and
+after from the same probe.
+
+If the driver itself misbehaves, say so plainly rather than reporting it as an
+app bug — the two input gotchas above both present as the app ignoring input.

--- a/.claude/skills/spicetify-drive/driver.mjs
+++ b/.claude/skills/spicetify-drive/driver.mjs
@@ -1,0 +1,216 @@
+// Drives the Spotify desktop client over the Chrome DevTools Protocol.
+//
+//   node driver.mjs <script.mjs> [--endpoint http://127.0.0.1:8088]
+//
+// The script must default-export an async function taking the driver object.
+// Node's built-in WebSocket does the work, so there is nothing to install.
+//
+//   export default async (d) => {
+//     console.log(await d.eval(`Spicetify.Player.data?.item?.name`));
+//   };
+
+import { writeFileSync } from 'node:fs';
+
+const arg = (flag, fallback) => {
+  const i = process.argv.indexOf(flag);
+  return i > -1 ? process.argv[i + 1] : fallback;
+};
+
+const endpoint = arg('--endpoint', 'http://127.0.0.1:8088');
+const scriptPath = process.argv[2];
+
+if (!scriptPath || scriptPath.startsWith('--')) {
+  console.error('usage: node driver.mjs <script.mjs> [--endpoint URL]');
+  process.exit(1);
+}
+
+// Spotify may still be booting, especially right after `spicetify apply` and a
+// relaunch, so poll rather than failing on the first refused connection.
+let page;
+for (let i = 0; i < 40; i += 1) {
+  try {
+    const targets = await (await fetch(`${endpoint}/json`)).json();
+    page = targets.find((t) => t.url.includes('xpui.app.spotify.com'));
+    if (page) break;
+  } catch {
+    // not listening yet
+  }
+  await new Promise((r) => setTimeout(r, 1000));
+}
+
+if (!page) {
+  console.error(`No xpui target at ${endpoint} after 40s.`);
+  console.error('Is Spotify running, and is always_enable_devtools = 1 in config-xpui.ini?');
+  process.exit(1);
+}
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+  ws.addEventListener('open', resolve, { once: true });
+  ws.addEventListener('error', reject, { once: true });
+});
+
+let nextId = 0;
+const pending = new Map();
+const consoleLines = [];
+
+ws.addEventListener('message', (event) => {
+  const msg = JSON.parse(event.data);
+
+  if (msg.method === 'Runtime.consoleAPICalled') {
+    const text = msg.params.args
+      .map((a) => a.value ?? a.description ?? a.unserializableValue ?? '?')
+      .join(' ');
+    consoleLines.push(`[${msg.params.type}] ${text}`);
+    return;
+  }
+
+  const p = pending.get(msg.id);
+  if (!p) return;
+  pending.delete(msg.id);
+  if (msg.error) p.reject(new Error(JSON.stringify(msg.error)));
+  else p.resolve(msg.result);
+});
+
+const send = (method, params = {}) => new Promise((resolve, reject) => {
+  const id = (nextId += 1);
+  pending.set(id, { resolve, reject });
+  ws.send(JSON.stringify({ id, method, params }));
+});
+
+const boxOf = async (selector) => {
+  const box = await d.eval(`(() => {
+    const el = document.querySelector(${JSON.stringify(selector)});
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  })()`);
+  if (!box) throw new Error(`no element matched ${selector}`);
+  return box;
+};
+
+const d = {
+  send,
+  consoleLines,
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+
+  /** Evaluate an expression in the page and return it by value. Awaits promises. */
+  async eval(expression) {
+    const r = await send('Runtime.evaluate', {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+      allowUnsafeEvalBlockedByCSP: true,
+    });
+    if (r.exceptionDetails) {
+      const e = r.exceptionDetails;
+      throw new Error(`eval failed: ${e.exception?.description ?? e.text}`);
+    }
+    return r.result?.value;
+  },
+
+  /** Poll an expression until it is truthy. Returns its value, throws on timeout. */
+  async waitFor(expression, { timeout = 10000, interval = 200 } = {}) {
+    const deadline = Date.now() + timeout;
+    for (;;) {
+      const value = await this.eval(expression);
+      if (value) return value;
+      if (Date.now() > deadline) throw new Error(`waitFor timed out: ${expression}`);
+      await this.sleep(interval);
+    }
+  },
+
+  /**
+   * A non-printable key (Escape, ArrowDown, Tab...). Pass the DOM key name and
+   * its keyCode: ArrowUp 38, ArrowDown 40, Enter 13, Escape 27, Tab 9,
+   * Backspace 8.
+   *
+   * Enter is special-cased. A rawKeyDown suppresses the keypress, and without
+   * that Chromium never runs a form's default submit -- so Enter needs a real
+   * keyDown carrying \r or nothing happens.
+   */
+  async key(key, keyCode) {
+    const base = {
+      key,
+      code: key,
+      windowsVirtualKeyCode: keyCode,
+      nativeVirtualKeyCode: keyCode,
+    };
+    if (key === 'Enter') {
+      await send('Input.dispatchKeyEvent', { type: 'keyDown', text: '\r', ...base });
+    } else {
+      await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', ...base });
+    }
+    await send('Input.dispatchKeyEvent', { type: 'keyUp', ...base });
+  },
+
+  /**
+   * Type printable text. Each character is a lone 'char' event: pairing it with
+   * a keyDown that also carries `text` inserts every character twice.
+   *
+   * Real events matter here -- assigning to input.value directly does not drive
+   * a React controlled input, and React is what Spotify's UI is built on.
+   */
+  async type(str, perCharDelay = 40) {
+    for (const ch of str) {
+      await send('Input.dispatchKeyEvent', { type: 'char', text: ch });
+      await this.sleep(perCharDelay);
+    }
+  },
+
+  /** Empty a React-controlled input, firing the input event React listens for. */
+  async clear(selector) {
+    await this.eval(`(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) throw new Error('no element matched ' + ${JSON.stringify(selector)});
+      const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+      set.call(el, '');
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    })()`);
+  },
+
+  async click(selector) {
+    const { x, y } = await boxOf(selector);
+    for (const type of ['mousePressed', 'mouseReleased']) {
+      await send('Input.dispatchMouseEvent', { type, x, y, button: 'left', clickCount: 1 });
+    }
+  },
+
+  /** Click by visible text, for buttons without a stable selector. */
+  async clickText(text, tag = 'button') {
+    const box = await this.eval(`(() => {
+      const el = [...document.querySelectorAll(${JSON.stringify(tag)})]
+        .find((n) => n.textContent.trim() === ${JSON.stringify(text)});
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    })()`);
+    if (!box) throw new Error(`no ${tag} with text ${JSON.stringify(text)}`);
+    for (const type of ['mousePressed', 'mouseReleased']) {
+      await send('Input.dispatchMouseEvent', { type, x: box.x, y: box.y, button: 'left', clickCount: 1 });
+    }
+  },
+
+  /** Scroll over an element. Useful for overscroll and scroll-chaining checks. */
+  async wheel(selector, deltaY, deltaX = 0) {
+    const { x, y } = await boxOf(selector);
+    await send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX, deltaY });
+  },
+
+  async shot(path) {
+    const { data } = await send('Page.captureScreenshot', { format: 'png' });
+    writeFileSync(path, Buffer.from(data, 'base64'));
+    return path;
+  },
+};
+
+await send('Runtime.enable');
+await send('Page.enable');
+
+try {
+  await (await import(scriptPath.startsWith('.') || scriptPath.startsWith('/')
+    ? new URL(scriptPath, `file://${process.cwd()}/`).href
+    : scriptPath)).default(d);
+} finally {
+  ws.close();
+}


### PR DESCRIPTION
Moves the project `CLAUDE.md` under `.claude/` — a documented project-instructions location alongside the repo root — and adds a `spicetify-drive` skill.

## Why

Reviewing #198 kept running into questions that could only be answered by the running Spotify client, not by reading code: does the `searchSuggestions` GraphQL definition actually exist, what shape does it return, which element really receives a click, does that scroll chain to the page. Spotify is Chromium, so the DevTools Protocol answers all of them directly.

Several conclusions in that review started as plausible guesses and only became facts after measuring. One of them — a fallback path that would have thrown `HttpResponseError` the day it was needed — was wrong until the client said so.

## What's in it

A dependency-free CDP driver (Node's built-in `WebSocket`) covering eval, `waitFor`, real key/mouse/wheel input, screenshots and console capture, plus the things that cost real time to work out:

- the endpoint is on **8088**, not the usual 9222, and there's no `--remote-debugging-port` flag to find
- `spicetify apply` **quits Spotify without relaunching it**
- a printable character must be a lone `char` event — pairing it with a `keyDown` that also carries `text` types everything twice
- Enter needs a real `keyDown` carrying `\r`, because a `rawKeyDown` suppresses the keypress that submits a form
- `input[role=combobox]` also matches Spotify's own search bar

The skill separates two modes, because their costs aren't comparable. **Inspect** attaches and reads — free, changes nothing, worth reaching for constantly. **Drive** rebuilds, runs `spicetify apply`, restarts Spotify and disturbs playback, so it says to ask first and includes the save/restore-state pattern.

## Notes

- The driver is smoke-tested against a live client: eval, `waitFor`, screenshot, console capture, and both absolute and relative script paths.
- `.claude/CLAUDE.md` is unchanged in content — moved only.
- Nothing here affects the built app; no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLigak1p9AmeyAYg7eNCkB