### PR TITLE
chore: version bump to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-that-tune",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/theRealPadster/name-that-tune",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor bump for the song autocomplete feature in #198, ahead of tagging 0.3.0.

Only `package.json` changes. The `0.2.0` in `.vscode/launch.json` is VS Code's own config-schema version, not the app version, so it stays as it is. `manifest.json` carries no version field, so the built output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLigak1p9AmeyAYg7eNCkB