### PR TITLE
fix: use the Spotify client locale for translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.8.0",
     "i18next": "^26.3.0",
-    "i18next-browser-languagedetector": "^8.2.1",
     "react-i18next": "^17.0.6",
     "spicetify-creator": "^1.0.17",
     "typescript": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       i18next:
         specifier: ^26.3.0
         version: 26.3.0(typescript@6.0.3)
-      i18next-browser-languagedetector:
-        specifier: ^8.2.1
-        version: 8.2.1
       react-i18next:
         specifier: ^17.0.6
         version: 17.0.6(i18next@26.3.0(typescript@6.0.3))(react@19.2.4)(typescript@6.0.3)
@@ -985,9 +982,6 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
-
-  i18next-browser-languagedetector@8.2.1:
-    resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
 
   i18next@26.3.0:
     resolution: {integrity: sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==}
@@ -2902,10 +2896,6 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
-
-  i18next-browser-languagedetector@8.2.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
 
   i18next@26.3.0(typescript@6.0.3):
     optionalDependencies:

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,7 +12,6 @@ import pl from './locales/pl.json';
 import ptBR from './locales/pt-BR.json';
 import uk from './locales/uk.json';
 import { initReactI18next } from 'react-i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
 
 import Game from './pages/Game';
 import Stats from './pages/Stats';
@@ -21,7 +20,6 @@ import './css/app.global.scss';
 
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
-  .use(LanguageDetector)
   .init({
     // the translations
     resources: {
@@ -36,10 +34,8 @@ i18n
       ptBR,
       uk,
     },
-    detection: {
-      order: [ 'navigator', 'htmlTag' ],
-    },
-    // lng: "en", // if you're using a language detector, do not define the lng option
+    // Use the locale the user picked in Spotify, not the embedded browser's — they can differ
+    lng: Spicetify.Locale.getLocale(),
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape

--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -12,34 +12,6 @@ import pl from '../locales/pl.json';
 import ptBR from '../locales/pt-BR.json';
 import uk from '../locales/uk.json';
 import { initReactI18next } from 'react-i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
-
-i18n
-  .use(initReactI18next) // passes i18n down to react-i18next
-  .use(LanguageDetector)
-  .init({
-    // the translations
-    resources: {
-      ca,
-      el,
-      en,
-      de,
-      es,
-      'es-419': esLatin,
-      fr,
-      pl,
-      ptBR,
-      uk,
-    },
-    detection: {
-      order: [ 'navigator', 'htmlTag' ],
-    },
-    // lng: "en", // if you're using a language detector, do not define the lng option
-    fallbackLng: 'en',
-    interpolation: {
-      escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
-    },
-  });
 
 (async () => {
   while (
@@ -47,11 +19,36 @@ i18n
       Spicetify?.Platform &&
       Spicetify?.ContextMenu &&
       Spicetify?.URI &&
+      Spicetify?.Locale &&
       Spicetify?.showNotification
     )
   ) {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
+
+  i18n
+    .use(initReactI18next) // passes i18n down to react-i18next
+    .init({
+      // the translations
+      resources: {
+        ca,
+        el,
+        en,
+        de,
+        es,
+        'es-419': esLatin,
+        fr,
+        pl,
+        ptBR,
+        uk,
+      },
+      // Use the locale the user picked in Spotify, not the embedded browser's — they can differ
+      lng: Spicetify.Locale.getLocale(),
+      fallbackLng: 'en',
+      interpolation: {
+        escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
+      },
+    });
 
   console.log('running name-that-tune extension');
 


### PR DESCRIPTION
Ports [spicetify/marketplace#1210](https://github.com/spicetify/marketplace/pull/1210) to this app.

## Summary

- initialize i18next from `Spicetify.Locale.getLocale()`
- remove the browser language detector and its dependency
- keep the existing English fallback for unsupported locales

## Root cause

`i18next-browser-languagedetector` was configured with `order: ['navigator', 'htmlTag']`. Both of those report the *embedded browser's* locale, which can differ from the language the user actually selected in Spotify's settings — so the wrong translations could load.

## Notes

The i18n init is duplicated verbatim in `src/app.tsx` and `src/extensions/extension.tsx` (the two bundles share no runtime state), so both are updated.

In the **extension** bundle the init moves inside the existing `Spicetify` poll, and `Spicetify?.Locale` joins the wait condition. That bundle is loaded at Spotify startup regardless of route, so reading `Spicetify.Locale` at module scope is a race. `t()` is only called after the poll, so nothing needed it earlier. The **app** bundle only mounts on navigation, so its init stays at module scope.

`Spicetify?.Locale` is ordered before `Spicetify?.showNotification` in that condition — with `showNotification` no longer last in the `&&` chain, `tsc` reports TS2774 on it.

## Verification

- `pnpm lint:ci && pnpm type-check && pnpm build:local` all pass
- probed the running client over the debug port to confirm the API and compare it against what the detector was reading:

```
hasLocale:         "object"
hasGetLocale:      "function"
Locale.getLocale() "en-GB"
navigator.language "en-GB"
```

They agree on this machine, which is the coincidence the fix stops relying on. `en-GB` also confirms the `fallbackLng: 'en'` chain still resolves (i18next tries `en-GB` → `en`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA