### PR TITLE
fix: register the Brazilian Portuguese locale under pt-BR

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -31,7 +31,7 @@ i18n
       'es-419': esLatin,
       fr,
       pl,
-      ptBR,
+      'pt-BR': ptBR,
       uk,
     },
     // Use the locale the user picked in Spotify, not the embedded browser's — they can differ

--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -39,7 +39,7 @@ import { initReactI18next } from 'react-i18next';
         'es-419': esLatin,
         fr,
         pl,
-        ptBR,
+        'pt-BR': ptBR,
         uk,
       },
       // Use the locale the user picked in Spotify, not the embedded browser's — they can differ


### PR DESCRIPTION
## Summary

`src/locales/pt-BR.json` was registered in the i18next `resources` map under the key `ptBR`:

```js
resources: {
  ...
  'es-419': esLatin,
  fr,
  pl,
  ptBR,     // <- never matches a locale code
  uk,
},
```

`ptBR` is not a locale code i18next will ever look up, so those translations have been unreachable and pt-BR users fell through to English. The `es-419` entry directly above it was already quoted correctly, which is what makes it look like an oversight rather than a convention.

Same one-line change in both bundles, since the i18n init is duplicated.

## Verification

Confirmed against the running Spotify client that the hyphenated form is what the client reports — `Spicetify.Locale._supportedLocales` contains:

```
"es", "es-419", "pt-PT", "pt-BR", "es-AR", "es-MX", ...
```

`navigator.language` used the same hyphenated form, so this was broken under the old language detector too — it is not a regression from #201.

`pnpm lint:ci && pnpm type-check && pnpm build:local` all pass.

## Note

These translations have been dormant for as long as the typo has existed, so they may have drifted behind `en.json` — worth a look from someone who reads pt-BR before or after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA