### PR TITLE
chore: add a release-drafting skill

### DIFF
--- a/.claude/skills/draft-release/SKILL.md
+++ b/.claude/skills/draft-release/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: draft-release
+description: Cut a new release of this Spicetify app — work out the version bump from what has merged since the last tag, write the release notes in this repo's house style, open the version-bump PR, then tag and draft the GitHub release once it is merged. Use when the user wants to release, cut a version, bump the version, or draft release notes.
+---
+
+# Drafting a release
+
+The thing users actually install is the **`dist` branch**, not the tag. `push-dist.yml`
+rebuilds and pushes it on every commit to `main`, so *`main` is released the moment
+anything merges* — the tag and the GitHub release are documentation written after
+the fact, not the mechanism.
+
+That has one practical consequence worth holding onto: there is no "unrelease". If the
+notes are wrong you edit them; if the code is wrong you ship another commit.
+
+## The shape of it
+
+| | |
+|---|---|
+| 1 | Gather the facts |
+| 2 | Propose the version, **confirm with the user** |
+| 3 | Draft the notes, **show them to the user** |
+| 4 | Open the `chore: version bump` PR |
+| — | **⏸ Stop. The user merges it.** |
+| 5 | Verify CI pushed `dist` |
+| 6 | Tag the bump commit |
+| 7 | `gh release create --draft` — the user publishes |
+
+Two hard stops: never merge the bump PR yourself, and never publish the release.
+Both are the user's call.
+
+## 1. Gather the facts
+
+```bash
+./.claude/skills/draft-release/gather.sh
+```
+
+Read-only, safe to run any time. It prints the last tag, every commit and PR since it,
+each PR's author and labels, detected new contributors, and the Spotify/Spicetify
+versions for the tested-against line.
+
+If it warns that `package.json` disagrees with the last tag, **stop and work out why**
+before bumping — usually it means a bump merged but was never tagged, and the fix is to
+tag the existing commit rather than bump again.
+
+## 2. Propose the version
+
+Semver against what the PRs actually do, not against their `fix:`/`feat:` prefixes:
+
+- **minor** — any new user-facing capability. 0.3.0 was a minor for one feature (song
+  autocomplete, #198).
+- **patch** — fixes, dependency bumps, internals only.
+- **major** — has not happened yet; the app is pre-1.0. Ask before assuming it.
+
+Say which PRs drove the call, then confirm the number with the user before touching
+anything.
+
+## 3. Draft the notes
+
+This is the part that takes judgement — everything else is mechanical. Read the actual
+PRs. Do not paste GitHub's auto-generated list, and do not just reformat PR titles.
+
+The format, from `gh release view 0.2.0` and `0.3.0`:
+
+```markdown
+## What's Changed
+
+**This release fixes the app being completely broken on current Spotify clients.**
+
+* Fix playlists failing to load after Spotify removed the endpoint they used, by @peternjorogew in https://github.com/theRealPadster/name-that-tune/pull/190
+* Allow starting a new game without leaving the game page first, by @theRealPadster in https://github.com/theRealPadster/name-that-tune/pull/196
+* Various dependency upgrades
+
+Tested against Spotify 1.2.94.583 with Spicetify 2.44.0.
+
+## New Contributors
+* @peternjorogew made their first contribution in https://github.com/theRealPadster/name-that-tune/pull/190
+
+**Full Changelog**: https://github.com/theRealPadster/name-that-tune/compare/0.1.7...0.2.0
+```
+
+The rules that actually matter:
+
+**One bold sentence up top saying what the release is *for*.** A reader deciding whether
+to update should need nothing else. "This release fixes the app being completely broken
+on current Spotify clients" — not "various fixes and improvements".
+
+**Bullets are per user-visible change, not per PR.** #190 produced four separate bullets
+in 0.2.0 because it fixed four distinct symptoms. One PR can be several bullets; several
+PRs can collapse into one.
+
+**Describe the symptom, not the diff.** "Fix playlists failing to load after Spotify
+removed the endpoint they used" beats "resync shuffle+ with upstream". The reader knows
+the game, not the codebase. Where a fix is Spotify's doing rather than ours, say so —
+it explains why a working app broke on its own.
+
+**Credit every author, the maintainer included.** Every bullet gets `by @author in <url>`,
+whoever wrote it — @theRealPadster's own work included.
+
+Note that this is a deliberate break from 0.1.x–0.3.0, which credited outside
+contributors but left the maintainer's own changes bare (compare the #190 and #196
+bullets as originally published). Do not copy that older pattern from `gh release view`;
+the example above already shows the current convention.
+
+**Leave internal work out entirely.** `chore:` PRs get no bullet — not the version bump
+itself, not tooling, not CI, not the Claude config. 0.3.0 shipped #198, #199 and #200
+and mentioned only #198. Roll Dependabot into one "Various dependency upgrades" line, or
+drop it if that is the whole release.
+
+**Tested-against comes from `gather.sh`,** which reads the live client over the debug
+port (see the `spicetify-drive` skill). That only knows the one client that happens to be
+running — 0.3.0 listed two Spotify versions. Ask the user whether they tested others
+before settling the line.
+
+Show the user the draft and take edits before opening anything.
+
+## 4. Open the bump PR
+
+Only `package.json` changes. `manifest.json` carries no version, and `dist/` is generated.
+
+```bash
+git checkout -b chore/version-bump-X.Y.Z
+# edit "version" in package.json
+git commit -am "chore: version bump to X.Y.Z"
+gh pr create --base main --title "chore: version bump to X.Y.Z" \
+  --body "Minor bump for <the headline change> in #NNN."
+```
+
+Keep the body to one line naming the bump's justification, as in #200.
+
+**Then stop and hand back to the user.** Everything below waits on that merge.
+
+## 5. Verify `dist` actually rebuilt
+
+The tag should point at a commit users can already install.
+
+```bash
+gh run list --workflow=push-dist.yml --limit 1
+git log --oneline -1 origin/dist
+```
+
+If the run failed, the release is a lie — sort that out before tagging.
+
+## 6. Tag the bump commit
+
+The tag goes on the bump commit itself, not on whatever landed after it. Both 0.2.0 and
+0.3.0 are tagged this way.
+
+```bash
+git fetch origin
+git tag X.Y.Z <bump-commit-sha>
+git push origin X.Y.Z
+```
+
+Plain lightweight tags, no `v` prefix — match `0.3.0`, not `v0.3.0`.
+
+Ignore the stray `dev-release` tag; `gather.sh` already filters it out.
+
+## 7. Create the draft
+
+```bash
+gh release create X.Y.Z --draft --title "X.Y.Z" --notes-file notes.md
+```
+
+Give the user the URL and let them publish. Write `notes.md` to the scratchpad, not the
+repo — this project keeps no CHANGELOG, and the release body is the only changelog there is.
+
+## Gotchas
+
+- **Squash merges renumber history.** Stacked release PRs conflict after the parent
+  squashes. Confirm the squashed content matches (`git diff <old-commit> origin/main`
+  should be empty) and then rebase, rather than resolving by hand.
+- **`gather.sh` reads `origin/main`, not your local `main`.** It fetches first, so a stale
+  local checkout will not silently produce short notes.
+- **New-contributor detection assumes lowest PR number = first contribution.** True for
+  this repo's history; it would misfire on someone whose first PR was closed and reopened.
+- **Version bump PRs land in the *next* release's commit range** and must be excluded from
+  its bullets. `gather.sh` lists them; you filter them.

--- a/.claude/skills/draft-release/gather.sh
+++ b/.claude/skills/draft-release/gather.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Collect every fact a release draft needs. Read-only — safe to run any time.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+git fetch -q origin 2>/dev/null
+
+# Highest semver tag. Not `git describe` — that would pick up `dev-release`.
+LAST_TAG=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+PKG_VERSION=$(grep -m1 '"version"' package.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+
+echo "last_tag:        $LAST_TAG"
+echo "package.json:    $PKG_VERSION"
+echo "repo:            $REPO"
+echo "compare_link:    https://github.com/$REPO/compare/$LAST_TAG...NEW_VERSION"
+echo
+
+if [ "$LAST_TAG" != "$PKG_VERSION" ]; then
+  echo "!! package.json ($PKG_VERSION) != last tag ($LAST_TAG)."
+  echo "!! A version bump may already be merged but untagged. Check before bumping again."
+  echo
+fi
+
+echo "=== commits since $LAST_TAG ==="
+git log --format='%h %s' "$LAST_TAG"..origin/main || echo "(none)"
+echo
+
+# PR numbers, oldest first, so the notes read chronologically.
+# awk, not `tac` — that is GNU-only and absent on macOS.
+PRS=$(git log --format='%s' "$LAST_TAG"..origin/main \
+      | grep -oE '\(#[0-9]+\)$' | tr -d '(#)' \
+      | awk '{a[NR]=$0} END{for(i=NR;i>0;i--) print a[i]}')
+
+if [ -z "$PRS" ]; then
+  echo "=== no PR-numbered commits in range ==="
+  echo "Commits were pushed straight to main. Write the notes from the subjects above."
+  exit 0
+fi
+
+echo "=== PRs in this release ==="
+AUTHORS=""
+for pr in $PRS; do
+  # shellcheck disable=SC2016
+  gh pr view "$pr" --json number,title,author,url,labels --jq \
+    '"#\(.number)\t\(.author.login)\t\(.title)\n        \(.url)\n        labels: \([.labels[].name] | join(", "))"'
+  AUTHORS="$AUTHORS $(gh pr view "$pr" --json author --jq .author.login)"
+done
+echo
+
+# New contributor = their lowest-numbered merged PR is one of this release's.
+echo "=== new contributors ==="
+FOUND=0
+for author in $(echo "$AUTHORS" | tr ' ' '\n' | sort -u | grep -v '^$'); do
+  first=$(gh pr list --state merged --author "$author" --limit 200 \
+          --json number --jq 'min_by(.number).number' 2>/dev/null)
+  if echo "$PRS" | grep -qx "$first"; then
+    echo "@$author (first contribution: #$first)"
+    FOUND=1
+  fi
+done
+[ "$FOUND" -eq 0 ] && echo "(none)"
+echo
+
+echo "=== tested-against versions ==="
+echo "spicetify:       $(spicetify -v 2>/dev/null || echo 'CLI not found')"
+SPOTIFY=$(curl -s -m 2 http://127.0.0.1:8088/json/version 2>/dev/null | grep -o 'Spotify/[0-9.]*' | cut -d/ -f2)
+if [ -n "$SPOTIFY" ]; then
+  echo "spotify:         $SPOTIFY (from the running client)"
+else
+  echo "spotify:         not running / debug port closed — ask the user"
+fi


### PR DESCRIPTION
Follows on from the `spicetify-drive` skill in #199 — same idea, applied to cutting a release.

## What this adds

`.claude/skills/draft-release/`, containing a `SKILL.md` and a `gather.sh` helper.

The flow it encodes, matching how 0.2.0 and 0.3.0 were actually done:

1. gather the facts
2. propose the version bump, confirm it
3. draft the notes, show them for edits
4. open the `chore: version bump` PR
5. **stop** — the maintainer merges it
6. verify `push-dist.yml` rebuilt the `dist` branch
7. tag the bump commit
8. `gh release create --draft`

Two hard stops are written into the skill: it never merges the bump PR and never publishes the release.

## gather.sh

Read-only, safe to run any time. One pass gives the last tag, every commit and PR since it, each PR's author and labels, detected new contributors, and the Spotify/Spicetify versions for the tested-against line:

```
last_tag:        0.3.0
package.json:    0.3.0
=== PRs in this release ===
#201  theRealPadster  fix: use the Spotify client locale for translations
#202  theRealPadster  fix: register the Brazilian Portuguese locale under pt-BR
=== new contributors ===  (none)
=== tested-against versions ===
spicetify:       2.44.0
spotify:         1.2.94.583 (from the running client)
```

It reads the live Spotify version over the debug port, so it depends on the same setup #199 documented. If Spotify is not running it says so and defers to you rather than guessing.

Two portability notes, both found by running it: `tac` is GNU-only and absent on macOS, so it reverses with awk; and `git describe` picks up the stray `dev-release` tag, so it selects the highest semver tag instead.

## Release notes conventions

Reverse-engineered from the 0.2.0 and 0.3.0 bodies — bullets are per user-visible change rather than per PR, they describe the symptom rather than the diff, and `chore:` PRs are left out entirely.

**One deliberate change from precedent:** bullets now credit the maintainer's own PRs (`by @theRealPadster in ...`), not just outside contributors. The skill flags this explicitly, so that reading the older releases back does not reintroduce the previous pattern.

## Verification

- `gather.sh` run against the current state of `main`; output above is real
- new-contributor detection validated against a known case — returns #190 for @peternjorogew, matching the hand-written 0.2.0 notes
- `bash -n` clean, `pnpm lint:ci` passes

No `src/` changes; nothing shipped to users is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA