### PR TITLE
fix: verify the dist branch by content, not by its head commit

### DIFF
--- a/.claude/skills/draft-release/SKILL.md
+++ b/.claude/skills/draft-release/SKILL.md
@@ -130,16 +130,35 @@ Keep the body to one line naming the bump's justification, as in #200.
 
 **Then stop and hand back to the user.** Everything below waits on that merge.
 
-## 5. Verify `dist` actually rebuilt
+## 5. Verify `dist` is current
 
-The tag should point at a commit users can already install.
+The tag should point at something users can already install.
 
 ```bash
-gh run list --workflow=push-dist.yml --limit 1
-git log --oneline -1 origin/dist
+./.claude/skills/draft-release/verify-dist.sh
 ```
 
-If the run failed, the release is a lie — sort that out before tagging.
+Exit 0 means `dist` matches main and it is safe to tag.
+
+**Do not judge this by `dist`'s head commit.** `push-dist.yml` ends in
+`git diff-index --quiet HEAD || git commit`, so it only commits when the *built output*
+changes. A release whose only new commit is the version bump changes no output — the
+version is not embedded in the bundle — so the run succeeds while `dist`'s head stays
+pointing at an older SHA. That looks like a failed deploy and is not one. 0.3.1 hit
+exactly this: `dist` read "generated at 111d1d1" (the PR before the bump) while its
+contents were entirely correct.
+
+So the script checks *content*, not commits: it confirms a successful `push-dist` run for
+main's current SHA, then rebuilds locally with CI's own `pnpm build:prod` and diffs the
+result against the branch. The build is reproducible, so a match is exact.
+
+It tolerates exactly one discrepancy, `preview.png` at the branch root — a stale artifact
+from an older layout that is no longer generated. The workflow builds into a checkout of
+`dist` without cleaning first, so nothing ever removes it. Anything *else* differing is a
+real problem: stop and work out why before tagging.
+
+The script clears `dist/` (gitignored build output) to get a clean comparison. Stop
+`pnpm watch` first if it is running.
 
 ## 6. Tag the bump commit
 

--- a/.claude/skills/draft-release/verify-dist.sh
+++ b/.claude/skills/draft-release/verify-dist.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Verify the `dist` branch — what users actually install — matches current main.
+#
+# Do NOT judge this by dist's head commit. push-dist.yml only commits when the
+# built output changes, so a release whose only commit is the version bump
+# leaves dist's head pointing at an older SHA while its *content* is correct.
+#
+# Rebuilds locally with the same command CI runs and diffs against the branch.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+git fetch -q origin 2>/dev/null
+
+STATUS=0
+
+echo "=== push-dist run for current main ==="
+HEAD_SHA=$(git rev-parse origin/main)
+gh run list --workflow=push-dist.yml --branch main --limit 5 \
+  --json headSha,conclusion,displayTitle,url \
+  --jq ".[] | select(.headSha == \"$HEAD_SHA\") | \"\(.conclusion)\t\(.displayTitle)\n\(.url)\"" \
+  | head -3
+RUN_OK=$(gh run list --workflow=push-dist.yml --branch main --limit 5 \
+         --json headSha,conclusion --jq \
+         "[.[] | select(.headSha == \"$HEAD_SHA\")] | first | .conclusion")
+if [ "$RUN_OK" != "success" ]; then
+  echo "!! no successful push-dist run for $(git rev-parse --short origin/main) (got: ${RUN_OK:-none})"
+  echo "!! dist may be stale. Do not tag until this is sorted."
+  STATUS=1
+fi
+echo
+
+echo "=== rebuilding locally with CI's command (pnpm build:prod) ==="
+# dist/ is gitignored build output, safe to clear. Stop `pnpm watch` first.
+rm -rf dist
+if ! pnpm build:prod >/dev/null 2>&1; then
+  echo "!! build:prod failed — run it directly to see why"
+  exit 1
+fi
+
+REF=$(mktemp -d)
+trap 'rm -rf "$REF"' EXIT
+git archive origin/dist | tar -x -C "$REF"
+
+echo "=== local build vs origin/dist ==="
+# preview.png is a stale artifact: it sits at the root of the dist branch but is
+# no longer generated. The workflow builds into a checkout of the branch without
+# cleaning, so it never gets removed. Expected — anything else is not.
+DIFF=$(diff -rq dist "$REF" 2>&1 | grep -v 'preview\.png$')
+
+if [ -z "$DIFF" ]; then
+  echo "identical (ignoring the known stale preview.png)"
+  echo
+  echo "dist is current with main. Safe to tag."
+else
+  echo "$DIFF"
+  echo
+  echo "!! dist does not match a local build of main."
+  echo "!! Check the push-dist run above before tagging."
+  STATUS=1
+fi
+
+exit $STATUS


### PR DESCRIPTION
Follow-up to #203, from actually cutting 0.3.1 with the skill.

## The problem

Step 5 told you to confirm CI had rebuilt `dist` like this:

```bash
gh run list --workflow=push-dist.yml --limit 1
git log --oneline -1 origin/dist
```

That second command reads as a failure whenever it isn't one.

`push-dist.yml` ends in `git diff-index --quiet HEAD || git commit`, so it only commits when the **built output** changes. A release whose only new commit is the version bump changes no output — the version isn't embedded in the bundle, and `manifest.json` carries no version field. The run succeeds, commits nothing, and `dist`'s head stays on an older SHA while its contents are perfectly current.

Cutting 0.3.1 hit exactly this. `origin/dist` read `Update to output generated at 111d1d1` — the commit *before* the bump — and was entirely up to date. Following the old step would have meant halting a correct release to investigate a non-problem.

## The fix

`verify-dist.sh` checks content instead of commits:

1. confirms a **successful** `push-dist` run exists for main's current SHA
2. rebuilds locally with CI's own `pnpm build:prod`
3. diffs the result against `origin/dist`

The build reproduces byte for byte, so a match is exact rather than a heuristic. Exit 0 means safe to tag; anything unexpected exits 1.

```
$ ./.claude/skills/draft-release/verify-dist.sh
=== push-dist run for current main ===
success	chore: version bump to 0.3.1 (#204)
https://github.com/theRealPadster/name-that-tune/actions/runs/31500727399

=== rebuilding locally with CI's command (pnpm build:prod) ===
=== local build vs origin/dist ===
identical (ignoring the known stale preview.png)

dist is current with main. Safe to tag.
```

## The one tolerated difference

`preview.png` at the root of the `dist` branch is a stale artifact from an older layout — nothing generates it any more. The workflow does `git worktree add ... dist` and then builds *into* that checkout without cleaning, so files that stopped being generated are never removed.

The filter only drops diff lines *ending* in `preview.png`, which is the "Only in" line. A genuine content difference in a file of that name still reports as `Files ... differ` and fails the check.

Left as-is deliberately — clearing it out is a change to `push-dist.yml` and to what users download, which doesn't belong in a docs fix. Worth its own issue if you want it gone.

## Verification

- script run against current `main`; output above is real
- `bash -n` clean
- confirmed the build is reproducible: a clean `pnpm build:prod` matches `origin/dist` exactly apart from that one file

No `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA