### PR TITLE
chore: point update-types at the renamed cli repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:ci": "eslint src",
     "type-check": "tsc --noEmit",
     "watch": "node scripts/build.mjs --watch",
-    "update-types": "curl -s -o src/types/spicetify.d.ts https://raw.githubusercontent.com/spicetify/spicetify-cli/master/globals.d.ts"
+    "update-types": "curl -s -o src/types/spicetify.d.ts https://raw.githubusercontent.com/spicetify/cli/main/globals.d.ts"
   },
   "license": "GPL-3.0",
   "engines": {


### PR DESCRIPTION
**Stacked on #208** (which is stacked on #207). GitHub retargets automatically as each lands.

## What

```diff
-"update-types": "curl ... spicetify/spicetify-cli/master/globals.d.ts"
+"update-types": "curl ... spicetify/cli/main/globals.d.ts"
```

`spicetify-cli` was renamed to `spicetify/cli` and its default branch to `main`. `spicetify/marketplace` already uses the new URL.

## This is not a fix for something broken

Worth being clear, since it looks like a bug fix: the old URL **still works**. It returns HTTP 200, and not via a redirect — GitHub is still resolving `spicetify-cli/master` directly. This is moving off a name that only keeps working by GitHub's grace, not repairing a failure.

## Verification

- both URLs return **byte-identical** content (2409 lines)
- that content already matches the committed `src/types/spicetify.d.ts`
- ran `pnpm update-types` after the change: `src/types/spicetify.d.ts` is untouched
- `type-check` passes

Zero behavioural change today. The point is that it keeps working if the old name is ever retired.

## Why stacked rather than on main

`update-types` sits directly below `watch` in the scripts block, and both #207 and #208 modify that block. Landing this on `main` independently would very likely conflict with #207 on merge. Stacking keeps the history linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA