### PR TITLE
refactor: share the i18next config between both bundles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,9 +43,13 @@ released on merge.
    startup regardless of route. `extension.tsx` polls until `Spicetify.Platform`/`ContextMenu`/`URI`
    exist, then registers the right-click menu entry and a `History.listen` handler.
 
-They share no runtime state. This is why i18n init is **duplicated verbatim** in `src/app.tsx` and
-`src/extensions/extension.tsx` — adding a locale means editing the `resources` map in *both*, plus
-dropping the JSON in `src/locales/`.
+They share no runtime state, so each ends up with its own i18next instance. The *configuration* is
+shared source, though: `src/i18n.ts` exports `initI18n()`, which both entry points call. Adding a
+locale means dropping the JSON in `src/locales/` and adding one line to that file.
+
+`initI18n()` reads `Spicetify.Locale`, so it must be called rather than run on import. `app.tsx` calls
+it at module scope, which is safe because the app bundle only loads on navigation; `extension.tsx`
+calls it after its startup poll, because extensions load before `Spicetify.Locale` necessarily exists.
 
 `react` / `react-dom` are marked external and rewritten to `Spicetify.React` / `Spicetify.ReactDOM`.
 Everything else is bundled, which is why all deps live in `devDependencies`.

--- a/.github/ISSUE_TEMPLATE/new_translation.yml
+++ b/.github/ISSUE_TEMPLATE/new_translation.yml
@@ -11,10 +11,26 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: locale-code
+    attributes:
+      label: Locale code
+      description: >-
+        Open the Spotify devtools console and run `Spicetify.Locale.getLocale()`.
+        Paste exactly what it prints — the file has to be named after it, hyphens
+        and all, or the translation never loads.
+      placeholder: e.g. es-419
+    validations:
+      required: true
+
   - type: textarea
     id: translation-json
     attributes:
       label: Translation JSON
+      description: >-
+        Some languages need more plural forms than English. Keys ending in `_one` /
+        `_other` follow i18next's plural rules — if yours also needs `_few` or
+        `_many` (Polish, for instance), include those too.
       placeholder: Copy src/locales/en.json and paste updated version here
       value: "```json\nCopy src/locales/en.json and paste updated version here\n```"
     validations:

--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ spicetify apply
 - (If you open the app directly from the header bar, it will just use the song you are currently playing.)
 
 ## Translations
-I've added translations support! If you use Spotify in a non-English language and are getting the "Play Name That Tune" menu item etc in English, you can get your language added by either: 
-- Submitting a pull request with a new copy of `src/locales/en.json` but named after your locale, with your translated content inside. 
-- Or making a [new issue](https://github.com/theRealPadster/name-that-tune/issues/new?labels=i18n&template=new_translation.yml) with the relevant translations from [`src/locales/en.json`](https://github.com/theRealPadster/name-that-tune/blob/main/src/locales/en.json). 
+I've added translations support! If you use Spotify in a non-English language and are getting the "Play Name That Tune" menu item etc in English, you can get your language added by either:
+
+- Making a [new issue](https://github.com/theRealPadster/name-that-tune/issues/new?labels=i18n&template=new_translation.yml) with the translated contents of [`src/locales/en.json`](https://github.com/theRealPadster/name-that-tune/blob/main/src/locales/en.json). No setup needed — I'll wire it up.
+- Or submitting a pull request:
+  1. Copy `src/locales/en.json` to `src/locales/<locale>.json` and translate the values.
+  2. **Register it in [`src/i18n.ts`](https://github.com/theRealPadster/name-that-tune/blob/main/src/i18n.ts)** — add the import and one entry to the `resources` map. A locale file that isn't listed there is never loaded, and the app silently falls back to English.
+
+`<locale>` has to match what Spotify reports, hyphens and all: `pt-BR`, `es-419`, `zh-CN` — not `ptBR`. You can check your own in the Spotify devtools console with `Spicetify.Locale.getLocale()`.
+
+Some languages need more plural forms than English does. Keys like `songWithCount` and `sendingURIs` use i18next's `_one` / `_other` suffixes; if your language also needs `_few` or `_many` (Polish, for instance), add those keys too.
 
 ## Planned Features
 - Possible "random" mode that doesn't use the beginning of the song, but grabs random segments from it

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,46 +1,17 @@
 import React from 'react';
 
-import i18n, { t } from 'i18next';
-import ca from './locales/ca.json';
-import el from './locales/el.json';
-import en from './locales/en.json';
-import de from './locales/de.json';
-import es from './locales/es.json';
-import esLatin from './locales/es-419.json';
-import fr from './locales/fr.json';
-import pl from './locales/pl.json';
-import ptBR from './locales/pt-BR.json';
-import uk from './locales/uk.json';
-import { initReactI18next } from 'react-i18next';
+import { t } from 'i18next';
+
+import initI18n from './i18n';
 
 import Game from './pages/Game';
 import Stats from './pages/Stats';
 
 import './css/app.global.scss';
 
-i18n
-  .use(initReactI18next) // passes i18n down to react-i18next
-  .init({
-    // the translations
-    resources: {
-      ca,
-      el,
-      en,
-      de,
-      es,
-      'es-419': esLatin,
-      fr,
-      pl,
-      'pt-BR': ptBR,
-      uk,
-    },
-    // Use the locale the user picked in Spotify, not the embedded browser's — they can differ
-    lng: Spicetify.Locale.getLocale(),
-    fallbackLng: 'en',
-    interpolation: {
-      escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
-    },
-  });
+// Safe at module scope: the app bundle is only loaded once the user navigates
+// to it, by which point Spicetify.Locale exists.
+initI18n();
 
 type HistoryLocation = {
   pathname: string;

--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -1,17 +1,8 @@
 import { toggleIsGuessing } from '../logic';
 
-import i18n, { t } from 'i18next';
-import ca from '../locales/ca.json';
-import el from '../locales/el.json';
-import en from '../locales/en.json';
-import de from '../locales/de.json';
-import es from '../locales/es.json';
-import esLatin from '../locales/es-419.json';
-import fr from '../locales/fr.json';
-import pl from '../locales/pl.json';
-import ptBR from '../locales/pt-BR.json';
-import uk from '../locales/uk.json';
-import { initReactI18next } from 'react-i18next';
+import { t } from 'i18next';
+
+import initI18n from '../i18n';
 
 (async () => {
   while (
@@ -26,29 +17,8 @@ import { initReactI18next } from 'react-i18next';
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
-  i18n
-    .use(initReactI18next) // passes i18n down to react-i18next
-    .init({
-      // the translations
-      resources: {
-        ca,
-        el,
-        en,
-        de,
-        es,
-        'es-419': esLatin,
-        fr,
-        pl,
-        'pt-BR': ptBR,
-        uk,
-      },
-      // Use the locale the user picked in Spotify, not the embedded browser's — they can differ
-      lng: Spicetify.Locale.getLocale(),
-      fallbackLng: 'en',
-      interpolation: {
-        escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
-      },
-    });
+  // Only after the poll above — initI18n reads Spicetify.Locale.
+  initI18n();
 
   console.log('running name-that-tune extension');
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,52 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import ca from './locales/ca.json';
+import el from './locales/el.json';
+import en from './locales/en.json';
+import de from './locales/de.json';
+import es from './locales/es.json';
+import esLatin from './locales/es-419.json';
+import fr from './locales/fr.json';
+import pl from './locales/pl.json';
+import ptBR from './locales/pt-BR.json';
+import uk from './locales/uk.json';
+
+/**
+ * Shared i18next setup for both bundles.
+ *
+ * The app and the extension are built separately and share no runtime state, so
+ * each ends up with its own i18next instance — this is a single source for the
+ * configuration, not a single instance.
+ *
+ * Adding a locale means adding the JSON to `src/locales/` and one line here.
+ *
+ * Must be called, not run on import: it reads `Spicetify.Locale`, and the
+ * extension loads at Spotify startup before that necessarily exists. The
+ * extension calls this only after its poll confirms it.
+ */
+export default function initI18n() {
+  return i18n
+    .use(initReactI18next) // passes i18n down to react-i18next
+    .init({
+      // the translations
+      resources: {
+        ca,
+        el,
+        en,
+        de,
+        es,
+        'es-419': esLatin,
+        fr,
+        pl,
+        'pt-BR': ptBR,
+        uk,
+      },
+      // Use the locale the user picked in Spotify, not the embedded browser's — they can differ
+      lng: Spicetify.Locale.getLocale(),
+      fallbackLng: 'en',
+      interpolation: {
+        escapeValue: false, // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
+      },
+    });
+}


### PR DESCRIPTION
**Stacked on #210** (→ #208 → #207). GitHub retargets automatically as each lands.

## The problem

The i18next init block was duplicated **character-for-character** in `src/app.tsx` and `src/extensions/extension.tsx` — same resources map, same `lng`, same `fallbackLng`, same comment. Adding a locale meant editing both. Miss one and the extension silently ships without the new language.

`CLAUDE.md` documented this as a known footgun rather than fixing it.

## The change

`src/i18n.ts` exports `initI18n()`; both entry points call it. Adding a locale is now one JSON file plus one line.

Net **−70 / +63 lines** across three files.

## Why it's a function, not a side effect of importing

`initI18n()` reads `Spicetify.Locale`. If it ran at import time, the extension would evaluate it at Spotify startup before its poll confirms that exists — reintroducing exactly the race #201 fixed.

So:

- `app.tsx` calls it at module scope — safe, the app bundle only loads on navigation
- `extension.tsx` calls it after its existing poll

Both call sites carry a comment saying which case they are, so neither gets "tidied up" later.

## What this does and doesn't do

**Does:** removes the duplication and the footgun.
**Does not:** change bundle size. Both bundles still compile in the full resources map — they share no runtime state, so each gets its own i18next instance. This shares the *configuration*, not the instance.

Groundwork for slimming the extension's i18n separately (it pulls 60 KB of i18next machinery for two strings) — that becomes "swap one import" rather than untangling a duplicated block.

## Verification

- `lint:ci`, `type-check`, `build:local`, `build:prod` all pass
- output diff vs pre-refactor: `index.js` +26 bytes, `extension.js` +26 bytes, `style.css` and `manifest.json` byte-identical
- both bundles still contain the locale resources, the `getLocale()` call and `fallbackLng: "en"`
- **ran in Spotify 1.2.94.583**: extension reaches its init without throwing (its startup log sits immediately after `initI18n()`), app renders fully translated, no raw keys on screen, no i18n or locale errors in console

One gap worth stating: I did not visually confirm the extension's translated context-menu label. It only appears for playlist/album/artist/folder URIs, and my attempts to force the menu open hit track rows instead. The init it depends on is confirmed to have run — the extension's own startup log follows `initI18n()` and appeared — so `t('menuEntry')` resolves against an initialised instance, but the rendered string itself is unverified.

`.claude/CLAUDE.md` updated: it described the duplication as intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA