### PR TITLE
chore: version bump to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-that-tune",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/theRealPadster/name-that-tune",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch bump for the build tooling replacement in #207, and the cleanups that followed in #208, #211 and #212. No user-facing changes.