### PR TITLE
fix: keep CSS module class names through minification

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,12 +69,22 @@ a contract with Spotify rather than choices to tidy up:
   load at startup, and `extension.tsx` imports `react-i18next`, so without the gate it evaluates
   against an undefined global.
 
-CSS modules use esbuild's native `local-css` loader — sass compiles the SCSS, esbuild scopes the class
-names. **This is why the module stylesheets are called `name-that-tune*.module.scss`.** esbuild builds
-scoped names from the file's *basename* alone, ignoring the directory, and adds no app-specific suffix;
-every Spicetify app's stylesheet loads into one shared document, so a generic `app.module.scss` here
-would collide with another app's. The prefix in the filename is the only thing making these unique —
-renaming them back, or "organising" them into a `name-that-tune/` folder, reintroduces the clash.
+CSS modules go through `postcss-modules`, not esbuild's native `local-css` loader, and the reason only
+shows up in a **minified** build: esbuild treats local class names as identifiers and renames them, so
+`--minify` collapses the stylesheet to `.i`, `.o`, `.s`. Every Spicetify app's CSS loads into one shared
+document, and any other app minified the same way draws from the same tiny pool. postcss-modules writes
+the scoped names in before esbuild sees them, and esbuild does not rename class names it did not create.
+
+**This is why the module stylesheets are called `name-that-tune*.module.scss`.** The scoped name is
+`[name]__[local]`, where `[name]` is the filename — so the prefix there is what keeps these unique
+between apps. Renaming them back to `app.module.scss`, or "organising" them into a `name-that-tune/`
+folder (the directory is not part of the name), reintroduces the clash.
+
+There is no content hash in the pattern: filename plus local name is already unique, and stable names
+are kinder to anyone writing custom CSS against the app.
+
+**Check CSS changes against `pnpm build:local`, not `pnpm build`.** Only the former minifies, and that is
+where class-name behaviour differs — a dev build looks correct while the shipped artifact is not.
 
 ### Routing
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.8.0",
     "i18next": "^26.3.0",
+    "postcss": "^8.5.26",
+    "postcss-modules": "^9.0.1",
     "react-i18next": "^17.0.6",
     "sass-embedded": "^1.100.0",
     "typescript": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,12 @@ importers:
       i18next:
         specifier: ^26.3.0
         version: 26.3.0(typescript@6.0.3)
+      postcss:
+        specifier: ^8.5.26
+        version: 8.5.26
+      postcss-modules:
+        specifier: ^9.0.1
+        version: 9.0.1(postcss@8.5.26)
       react-i18next:
         specifier: ^17.0.6
         version: 17.0.6(i18next@26.3.0(typescript@6.0.3))(react@19.2.4)(typescript@6.0.3)
@@ -602,6 +608,11 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -807,6 +818,9 @@ packages:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
 
+  generic-names@4.0.0:
+    resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -884,6 +898,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  icss-utils@5.1.0:
+    resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1058,9 +1078,16 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  loader-utils@3.3.1:
+    resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
+    engines: {node: '>= 12.13.0'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -1090,6 +1117,11 @@ packages:
 
   n-gram@2.0.2:
     resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1170,6 +1202,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -1177,6 +1212,47 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-modules-extract-imports@3.1.0:
+    resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-modules-local-by-default@4.2.0:
+    resolution: {integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-modules-scope@3.2.1:
+    resolution: {integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-modules-values@4.0.0:
+    resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
+    engines: {node: ^10 || ^12 || >= 14}
+    peerDependencies:
+      postcss: ^8.1.0
+
+  postcss-modules@9.0.1:
+    resolution: {integrity: sha512-BrSXxWSls23TzqMuplpeMRL5VHnDOLh2H9EiHNTMIdLBFumJcurDIi47TBuvkn9GsoTLAoPjv2wLzAt1wdQ2aQ==}
+    engines: {node: '>=20.6'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1430,6 +1506,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-hash@1.1.3:
+    resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2126,6 +2205,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   data-view-buffer@1.0.2:
@@ -2455,6 +2536,10 @@ snapshots:
 
   generator-function@2.0.1: {}
 
+  generic-names@4.0.0:
+    dependencies:
+      loader-utils: 3.3.1
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -2534,6 +2619,10 @@ snapshots:
   i18next@26.3.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
+
+  icss-utils@5.1.0(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
 
   ignore@5.3.2: {}
 
@@ -2714,9 +2803,13 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  loader-utils@3.3.1: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -2739,6 +2832,8 @@ snapshots:
   ms@2.1.3: {}
 
   n-gram@2.0.2: {}
+
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2832,9 +2927,57 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@4.0.5: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.26):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+      postcss-value-parser: 4.2.0
+
+  postcss-modules-scope@3.2.1(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  postcss-modules-values@4.0.0(postcss@8.5.26):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+
+  postcss-modules@9.0.1(postcss@8.5.26):
+    dependencies:
+      generic-names: 4.0.0
+      icss-utils: 5.1.0(postcss@8.5.26)
+      lodash.camelcase: 4.3.0
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
+      string-hash: 1.1.3
+
+  postcss-selector-parser@7.1.5:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -3096,13 +3239,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-hash@1.1.3: {}
 
   string-width@4.2.3:
     dependencies:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -12,6 +12,8 @@
 
 import * as esbuild from 'esbuild';
 import { compileAsync } from 'sass-embedded';
+import postcss from 'postcss';
+import postcssModules from 'postcss-modules';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import fs from 'node:fs';
@@ -104,24 +106,63 @@ const externalGlobals = {
   },
 };
 
-// SCSS. Compile with sass, then hand the result to esbuild, which does CSS
-// modules itself: `local-css` scopes class names and gives the importing module
-// a local-name -> scoped-name map.
+// SCSS + CSS modules. sass compiles, postcss-modules scopes the class names.
 //
-// esbuild builds those scoped names from the file's BASENAME alone — the
-// directory is ignored — and adds no app-specific suffix. Every Spicetify app's
-// stylesheet loads into one shared document, so a generically named
-// `app.module.scss` here would collide with another app's. That is why these
-// files are named `name-that-tune*.module.scss`: the prefix is what makes the
-// generated names unique, and renaming them back would reintroduce the clash.
+// esbuild can do CSS modules itself via its `local-css` loader, and this used to.
+// The catch only shows up in a minified build: esbuild treats local class names
+// as identifiers and renames them, so `--minify` turns the whole stylesheet into
+// `.i`, `.o`, `.s`. Every Spicetify app's CSS loads into one shared document, and
+// any other app minified the same way draws from that same tiny pool — so the
+// shipped artifact was the one place the names were *not* unique. An unminified
+// build looked fine, which is exactly how it got missed.
+//
+// postcss-modules writes the scoped names into the CSS before esbuild sees it,
+// and esbuild does not rename class names it did not create. So these survive
+// minification intact.
+//
+// `[name]` is the filename, which is why these files are `name-that-tune*` —
+// that prefix is what makes the names unique between apps. No content hash: the
+// filename plus the local name is already unique, and stable names are kinder to
+// anyone writing custom CSS against the app.
 const scss = {
   name: 'scss',
   setup(build) {
+    const cssStore = new Map();
+
+    build.onResolve({ filter: /\.module\.scss\.css$/ }, (args) => ({
+      path: args.path,
+      namespace: 'virtual-css',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'virtual-css' }, (args) => ({
+      contents: cssStore.get(args.path),
+      loader: 'css',
+    }));
+
     build.onLoad({ filter: /\.scss$/ }, async (args) => {
       const { css } = await compileAsync(args.path, { loadPaths: [path.dirname(args.path)] });
+
+      // Global stylesheets are written by hand and already namespaced.
+      if (!args.path.endsWith('.module.scss')) {
+        return { contents: css, loader: 'css' };
+      }
+
+      let exported = {};
+      const result = await postcss([
+        postcssModules({
+          generateScopedName: '[name]__[local]',
+          getJSON: (_, json) => { exported = json; },
+        }),
+      ]).process(css, { from: args.path });
+
+      // Feed the CSS back through a virtual import so it lands in the shared
+      // stylesheet as plain CSS, and export the local -> scoped name map. The
+      // path is repo-relative because esbuild writes it into a provenance
+      // comment, and an absolute one would differ between a local build and CI.
+      const virtual = `${path.relative(root, args.path)}.css`;
+      cssStore.set(virtual, result.css);
       return {
-        contents: css,
-        loader: args.path.endsWith('.module.scss') ? 'local-css' : 'global-css',
+        contents: `import ${JSON.stringify(virtual)};\nexport default ${JSON.stringify(exported)};`,
+        loader: 'js',
         resolveDir: path.dirname(args.path),
       };
     });


### PR DESCRIPTION
Fixes a regression I introduced in #212. Forward fix — #212's commits stay as they are.

## What went wrong

#212 moved CSS modules onto esbuild's native `local-css` loader, reasoning that naming the files `name-that-tune*.module.scss` was enough to keep generated class names unique between apps. **That held for an unminified build and not for the one that ships.**

esbuild treats local class names as identifiers and renames them, so `--minify` collapsed the whole stylesheet:

```css
.i{display:flex;justify-content:center;...}.s{font-size:50px}.p{...}.o{...}
```

Every Spicetify app's CSS loads into one shared document, and any other app minified the same way draws from that same tiny pool. So the shipped artifact was the one place the names were *not* unique — the exact property #212 claimed to guarantee.

Every check I ran was against `pnpm build`, which doesn't minify. That's how it got through.

Not currently breaking anything: I scanned every stylesheet in the live client and only four one-or-two-character class names exist across all of Spotify's own CSS (`no`, `os`, `x-`), so `.i`/`.s`/`.p` don't collide today. It was fragile, not broken.

## The fix

Back to `postcss-modules`. It writes the scoped names into the CSS before esbuild sees it, and esbuild does not rename class names it did not create — so they survive minification.

The alternative was `minifyIdentifiers: false`, which preserves the CSS names but stops JS identifier mangling too:

| approach | JS | CSS | shipped names |
|---|---:|---:|---|
| `local-css` + minify (broken) | 244,636 | 3,721 | `.i`, `.s`, `.p` |
| `minifyIdentifiers: false` | **360,774** | 4,794 | full |
| **postcss-modules (this PR)** | **244,326** | 4,828 | full |

+116 KB of JS was not a reasonable price for CSS naming.

## Naming

Scoped pattern is `[name]__[local]`:

```
.name-that-tune-module__container
.name-that-tune-button-module__button
```

`[name]` is the filename, so the `name-that-tune` prefix from #212 is still what makes these unique — those renames were right and are kept.

**No content hash**, unlike spicetify-creator's `[name]__[local]___[hash:base64:5]_nameDthatDtune`. Filename plus local name is already unique, and stable names are kinder to anyone writing custom CSS against the app — these now stay put instead of moving every time a style changes.

## Verification — against the minified build this time

- `grep` of minified `style.css`: all 19 classes full-length, **zero** one- or two-character classes
- `lint:ci`, `type-check`, `build:local`, `build:prod` pass
- copied the actual `dist` artifact into the live CustomApps folder and ran **Spotify 1.2.94.583**:

```
containerClass: "name-that-tune-module__container"   display: flex, gap: 20px
buttonClass:    "name-that-tune-button-module__button"  borderRadius: 500px
shortClassesInOurSheet: []
```

- renders identically, screenshot-checked

`CLAUDE.md` now says to check CSS changes with `pnpm build:local`, not `pnpm build` — only the former minifies, and that gap is what hid this.

## Note on release

0.3.2 is **not tagged**. The draft notes told users the new class name was `.name_that_tune_module_container`, which was wrong for the shipped build. Worth landing this first so the release describes what actually ships — the names will then be `.name-that-tune-module__container`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHfzKtD7gxhH55aUTBwXNA