### PR TITLE
fix: translate song suggestions label

### DIFF
--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Has guanyat!",
     "guessPlaceholder": "Esbrinar la cançó",
+    "suggestionsLabel": "Suggeriments des cançons",
     "playXSeconds": "Reproduïr {{count}}s",
     "guessBtn": "Esbrinar",
     "skipBtn": "Saltar",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Das war richtig!",
     "guessPlaceholder": "Rate den Titel",
+    "suggestionsLabel": "Titelvorschläge",
 	  "playXSeconds": "Spiele {{count}}s ab",
     "guessBtn": "Raten",
     "skipBtn": "Überspringen",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Κέρδισες!",
     "guessPlaceholder": "Βρες το Τραγούδι",
+    "suggestionsLabel": "Προτάσεις τραγουδιών",
     "playXSeconds": "Παίξε {{count}}s",
     "guessBtn": "Μάντεψε",
     "skipBtn": "Παράλειψη",

--- a/src/locales/es-419.json
+++ b/src/locales/es-419.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Ganaste!",
     "guessPlaceholder": "Adivina la canción",
+    "suggestionsLabel": "Sugerencias de canciones",
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
     "skipBtn": "Saltar",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "¡Correcto!",
     "guessPlaceholder": "Adivina la canción",
+    "suggestionsLabel": "Sugerencias de canciones",
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
     "skipBtn": "Saltar",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Vous avez gagné !",
     "guessPlaceholder": "Devinez la chanson",
+    "suggestionsLabel": "Suggestions de chansons",
     "playXSeconds": "Jouer à {{count}}s",
     "guessBtn": "Devinez",
     "skipBtn": "Passer",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Wygrałeś!",
     "guessPlaceholder": "Zgadnij tytuł",
+    "suggestionsLabel": "Sugestie utworów",
     "playXSeconds": "Odtwórz {{count}}s",
     "guessBtn": "Zgadnij",
     "skipBtn": "Pomiń",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Você acertou!",
     "guessPlaceholder": "Adivinhe a música",
+    "suggestionsLabel": "Sugestões de músicas",
     "playXSeconds": "Tocar {{count}}s",
     "guessBtn": "Adivinhar",
     "skipBtn": "Mais Tempo",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -4,6 +4,7 @@
     "title": "🎵 $t(appName)",
     "winMsg": "Ви перемогли!",
     "guessPlaceholder": "Назва пісні",
+    "suggestionsLabel": "Пропозиції пісень",
     "playXSeconds": "Слухати {{count}}с",
     "guessBtn": "Вгадати",
     "skipBtn": "Пропустити",


### PR DESCRIPTION
## Summary

Adds localized values for `suggestionsLabel` to all nine non-English locale files:

- Catalan
- German
- Greek
- Latin American Spanish
- Spanish
- French
- Polish
- Brazilian Portuguese
- Ukrainian

This prevents screen readers from falling back to the English “Song suggestions” label when the game is running in another supported language.

## Testing

- Confirmed all locale files contain valid JSON.
- `pnpm run type-check` passes.
- `pnpm run lint:ci` passes.
- `pnpm run build:local` succeeds.

Fixes #206