### PR TITLE
fix: keep the stats button clear of the player bar

### DIFF
--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -79,15 +79,11 @@
   color: var(--spice-text) !important;
   background-color: transparent !important;
   padding: 12px !important;
-
-  position: fixed !important;
-  bottom: 4px;
-  right: 4px;
 }
 
 :global(body.name-that-tune.name-that-tune--guessing) .container {
   width: 100%;
-  min-height: calc(100vh - 140px);
+  min-height: 100%;
   box-sizing: border-box;
   background-color: var(--spice-main);
   background-image: none;

--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -1,9 +1,11 @@
 .container {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   flex-direction: column;
   gap: 20px;
+  box-sizing: border-box;
+  padding-top: 40px;
 }
 
 .title {


### PR DESCRIPTION
## Summary

Two fixes to `name-that-tune.module.scss`, one per commit.

### The stats button (#216)

The button used `position: fixed; bottom: 4px; right: 4px`, and the reporter's guess that "a transformed ancestor may also explain why `right: 4px` does not position it at the viewport's right edge" was correct. Spotify's own `.Root__main-view` sets `container-type: size`, which establishes a containing block for fixed descendants, so the button was always positioned 4px from *that* box rather than from the window.

Working back from the coordinates in the issue via `bottom: 4px` / `right: 4px`, against a stock 1.2.96.518 client for comparison:

| | stock client | reporter |
|---|---|---|
| viewport | 1512 × 949 | 1794 × 1039 |
| containing block, right edge | 1076 | 1358.4 |
| **inset from viewport right** | **436px** | **435.6px** |
| containing block, bottom edge | 861 | 1031.8 |
| **inset from viewport bottom** | **88px** | **7.2px** |

The horizontal inset matches to within half a pixel, so the same ancestor is capturing the button in both cases. Only its height differs. On the stock layout it stops at 861, exactly where the player bar begins, so `bottom: 4px` looked deliberate. The reporter's theme stretches the main view to within ~7px of the window bottom and floats the player bar over it, so the same rule puts the button behind the bar.

That also rules out the tempting fix: anchoring to `.container` with `position: absolute` does not help, because the container fills that same box and inherits the same overlap. Staying in the normal flex flow is what avoids it — which is what the issue proposed.

### The scrollbar

Separate bug, found while testing. `min-height: calc(100vh - 140px)` assumed Spotify's chrome takes 140px. Measured on both 1.2.94.583 and 1.2.96.518 it takes 152px (64px top bar + 88px player bar), so the container was 12px taller than the space it sits in and put a scrollbar on the game page. `min-height: 100%` sizes against the main view instead of arithmetic on the window, and degrades to 0 rather than overflowing if Spotify stops giving it a definite height.

### Top-anchored layout

Unrelated to the issue, included because it is one line away. The container centred vertically, so each guess re-centred the whole stack and moved the title, input and buttons mid-round. `justify-content: flex-start` plus `padding-top: 40px` holds them still. `box-sizing` moves to the base class because the new padding would otherwise add to `min-height: 100%` and put the scrollbar back.

## Testing

Measured in a live 1.2.96.518 client over the debug port, not just eyeballed.

Stats button and scrollbar:

| | before | after |
|---|---|---|
| computed position | `fixed` | `relative` |
| button rect | 809 → 857 | 610 → 658 |
| container `min-height` | `809px` | `100%` (= 797px) |
| scroll overflow | **12px** | **0px** |
| clicking it navigates | — | ✅ `/name-that-tune/stats` |

Layout stability, three wrong guesses in a row:

| | 0 guesses | 1 | 2 | 3 |
|---|---|---|---|---|
| title top | 104 | 104 | 104 | 104 |
| input top | 193 | 193 | 193 | 193 |
| overflow | 0 | 0 | 0 | 0 |

Also checked the stats page, which shares `.container` — top-anchored, chart fully visible, no scrollbar.

- `pnpm lint:ci` passes.
- `pnpm type-check` passes.
- `pnpm build:local` succeeds, and all 17 scoped class names survive minification (`.name-that-tune-module__StatsButton` et al), so this does not disturb the postcss-modules arrangement from #214.

## Caveat

The stats button fix is verified on a stock client, where the old rule already worked. It is reasoned rather than measured for the reporter's theme: it can no longer fail the same way, because it no longer anchors to the bottom of anything, but I have not run it under that theme.

Fixes #216
