### PR TITLE
feat: game screen redesign and end-of-round reveal

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,19 +6,32 @@ import styles from '../css/name-that-tune-button.module.scss';
 // Circle is used by the install/remove button
 type ButtonType = 'round' | 'circle';
 
+// Visual weight, so that controls with different stakes do not all shout at the
+// same volume. 'neutral' is the original filled pill and stays the default.
+type ButtonVariant = 'neutral' | 'primary' | 'secondary' | 'tertiary';
+
 const Button = (props: {
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   classes?: string[];
   label?: string;
   type?: ButtonType;
+  variant?: ButtonVariant;
   children: React.ReactNode;
   disabled?: boolean;
 }) => {
   const buttonType = props.type || 'round';
+  const variant = props.variant || 'neutral';
 
   const classList = [styles.button];
   if (buttonType === 'circle') {
     classList.push(styles.circle);
+  }
+  if (variant === 'primary') {
+    classList.push(styles.primary);
+  } else if (variant === 'secondary') {
+    classList.push(styles.secondary);
+  } else if (variant === 'tertiary') {
+    classList.push(styles.tertiary);
   }
   if (props.classes) {
     classList.push(...props.classes);

--- a/src/components/GuessItem.tsx
+++ b/src/components/GuessItem.tsx
@@ -7,10 +7,26 @@ const GuessItem = (props: {
   won: boolean;
   index: number;
 }) => {
+  const guess = props.guesses[props.index];
   const correct = props.won && (props.index === props.guesses.length - 1);
+  const skipped = !guess;
+
+  const classList = [styles.guessItem];
+  if (correct) {
+    classList.push(styles.correct);
+  }
+  if (skipped) {
+    classList.push(styles.skipped);
+  }
+
+  // The markers are not aria-hidden on purpose: they are the only thing telling
+  // a screen reader whether a row was right, wrong or skipped.
   return (
-    <li className={correct ? styles.correct : undefined}>
-      {correct ? '✔' : 'x'} {props.guesses[props.index] || 'SKIPPED'}
+    <li className={classList.join(' ')}>
+      <span className={styles.guessMark}>
+        {correct ? '✔' : skipped ? '–' : '✕'}
+      </span>
+      <span className={styles.guessText}>{guess || 'SKIPPED'}</span>
     </li>
   );
 };

--- a/src/components/Reveal.tsx
+++ b/src/components/Reveal.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import styles from '../css/name-that-tune.module.scss';
+
+/**
+ * Shown once a round ends, win or lose. Until this existed the answer only
+ * appeared because the guessing body class dropped and Spotify's own now-playing
+ * bar came back, so the payoff happened in someone else's UI.
+ */
+const Reveal = (props: {
+  won: boolean;
+  attempts: number;
+}) => {
+  const { t } = useTranslation();
+
+  const item = Spicetify.Player.data?.item;
+
+  // Spotify serves these as spotify:image: URIs rather than https, and the
+  // client resolves them natively - no need to rewrite them to the CDN host.
+  const artwork = item?.metadata?.image_xlarge_url;
+
+  // The artists array credits everyone; metadata.artist_name only carries the
+  // first, which drops the second name on a collaboration.
+  const artists = (item?.artists ?? []).map((artist) => artist.name).join(' · ');
+
+  const verdictClasses = [styles.revealVerdict];
+  if (!props.won) {
+    verdictClasses.push(styles.revealVerdictLost);
+  }
+
+  return (
+    // The win or loss is otherwise silent to a screen reader, since nothing
+    // takes focus when the round ends.
+    <div className={styles.reveal} aria-live={'polite'}>
+      {artwork ? (
+        // Decorative: the title sits directly below, so alt text would only
+        // make a screen reader announce the same track twice.
+        <img className={styles.revealArt} src={artwork} alt={''} />
+      ) : null}
+
+      <p className={verdictClasses.join(' ')}>
+        {props.won
+          ? t('reveal.wonIn', { count: props.attempts })
+          : t('reveal.gaveUpAfter', { count: props.attempts })}
+      </p>
+
+      <h2 className={styles.revealTitle}>{item?.name}</h2>
+
+      {artists ? (
+        <p className={styles.revealArtist}>{artists}</p>
+      ) : null}
+
+      {!props.won ? (
+        <p className={styles.revealMeta}>{t('reveal.playingInFull')}</p>
+      ) : null}
+    </div>
+  );
+};
+
+export default Reveal;

--- a/src/css/name-that-tune-button.module.scss
+++ b/src/css/name-that-tune-button.module.scss
@@ -41,7 +41,10 @@
   padding-block: 12px;
   padding-inline: 32px;
 
-  &:hover {
+  // :hover still matches a disabled button - unlike :active, which the browser
+  // suppresses - so every hover effect has to opt out of it explicitly, or a
+  // button you cannot press still reacts to the pointer.
+  &:hover:not(:disabled) {
     transform: scale(1.04);
   }
 
@@ -77,7 +80,7 @@
   color: var(--spice-text);
   box-shadow: inset 0 0 0 1px var(--spice-subtext);
 
-  &:hover {
+  &:hover:not(:disabled) {
     box-shadow: inset 0 0 0 1px var(--spice-text);
   }
 
@@ -98,7 +101,7 @@
   text-decoration: underline;
   text-underline-offset: 3px;
 
-  &:hover {
+  &:hover:not(:disabled) {
     color: var(--spice-text);
     transform: none;
   }

--- a/src/css/name-that-tune-button.module.scss
+++ b/src/css/name-that-tune-button.module.scss
@@ -57,6 +57,58 @@
   }
 }
 
+// Variants below override .button, so they have to stay after it in the file -
+// they carry the same specificity and win on source order alone.
+
+// The one action the round is about.
+.primary {
+  background-color: var(--spice-button);
+  color: var(--spice-main);
+
+  &:active {
+    background-color: var(--spice-button-active, var(--spice-button));
+  }
+}
+
+// A real alternative to the primary action rather than a lesser version of it,
+// so it is outlined rather than a dimmer fill.
+.secondary {
+  background-color: transparent;
+  color: var(--spice-text);
+  box-shadow: inset 0 0 0 1px var(--spice-subtext);
+
+  &:hover {
+    box-shadow: inset 0 0 0 1px var(--spice-text);
+  }
+
+  &:active {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 1px var(--spice-subtext);
+  }
+}
+
+// Findable without inviting a click. Used for the one-way exits.
+.tertiary {
+  background-color: transparent;
+  color: var(--spice-subtext);
+  font-size: 12px;
+  font-weight: 600;
+  padding-block: 6px;
+  padding-inline: 8px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+
+  &:hover {
+    color: var(--spice-text);
+    transform: none;
+  }
+
+  &:active {
+    background-color: transparent;
+    transform: none;
+  }
+}
+
 .circle {
   padding-inline: 16px;
   width: 48px;

--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -158,6 +158,12 @@
 .skipped .guessText {
   font-style: italic;
   opacity: 0.75;
+
+  // Spotify's UI font ships no italic, so the browser slants the upright face
+  // and the last glyph's ink then overhangs its advance width by ~1.3px. The
+  // overflow: hidden above clips that, shaving the edge off the final letter -
+  // "Skipped" renders as "Skippea". Give the slant somewhere to land.
+  padding-inline-end: 2px;
 }
 
 .correct {

--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -66,6 +66,56 @@
   }
 }
 
+// The end-of-round reveal: artwork, how it went, and what the song was.
+.reveal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: min(420px, 90vw);
+  text-align: center;
+}
+
+.revealArt {
+  width: 160px;
+  height: 160px;
+  border-radius: 7px;
+  box-shadow: 0 10px 30px rgb(0 0 0 / 55%);
+}
+
+.revealVerdict {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--spice-button);
+}
+
+// Giving up is not a failure state worth colouring, so it drops to the muted
+// text colour rather than borrowing the error red.
+.revealVerdictLost {
+  color: var(--spice-subtext);
+}
+
+.revealTitle {
+  margin: 0;
+  font-size: 22px;
+  color: var(--spice-text);
+}
+
+.revealArtist {
+  margin: 0;
+  font-size: 13px;
+  color: var(--spice-subtext);
+}
+
+.revealMeta {
+  margin: 0;
+  font-size: 12px;
+  color: var(--spice-subtext);
+}
+
 // Wrong guesses are attempts, not errors, so they sit on a neutral card and let
 // the marker carry the meaning. Only the correct one spends any colour.
 .guessList {

--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -24,11 +24,6 @@
   color: var(--spice-text);
 }
 
-.subtitle {
-  font-size: 24px;
-  margin: 0;
-}
-
 .button {
   padding: 10px;
   border-radius: 10px;

--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -120,13 +120,17 @@
   }
 }
 
-// Container for the guess/skip buttons
+// Container for the guess/skip buttons. Spans the form so that guess can take
+// the room and skip can sit beside it at its natural width.
 .formButtonContainer {
   display: flex;
-  justify-content: center;
   align-items: center;
-  // flex-direction: column;
-  gap: 20px;
+  gap: 10px;
+  width: 100%;
+}
+
+.guessButton {
+  flex: 1 1 auto;
 }
 
 // The button stylesheet is bundled after this one, so .button wins any property

--- a/src/css/name-that-tune.module.scss
+++ b/src/css/name-that-tune.module.scss
@@ -8,13 +8,25 @@
   padding-top: 40px;
 }
 
+// The heading and the stats link share a row across the top of the game column,
+// which keeps stats reachable without it drifting down as guesses accumulate.
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: min(420px, 90vw);
+}
+
 .title {
-  font-size: 50px;
+  font-size: 22px;
+  margin: 0;
   color: var(--spice-text);
 }
 
 .subtitle {
-  font-size: 40px;
+  font-size: 24px;
+  margin: 0;
 }
 
 .button {
@@ -41,30 +53,70 @@
   width: 100%;
   margin: 0;
   padding: 10px 14px;
-  background-color: var(--spice-main);
+  background-color: var(--spice-card);
   color: var(--spice-text);
   font-size: 14px;
-  border: 1px solid var(--spice-text);
-  border-radius: 2px;
+  border: 1px solid transparent;
+  border-radius: 6px;
   box-sizing: border-box;
 
   &:focus {
-    border: 1px solid var(--spice-button);
+    outline: none;
+    border-color: var(--spice-text);
   }
 }
 
+// Wrong guesses are attempts, not errors, so they sit on a neutral card and let
+// the marker carry the meaning. Only the correct one spends any colour.
 .guessList {
-  list-style-type: decimal;
+  list-style: none;
+  width: min(420px, 90vw);
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 
   &:empty {
     display: none;
   }
+}
 
-  li {
-    color: var(--spice-notification-error);
-    &.correct {
-      color: var(--spice-button);
-    }
+.guessItem {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 11px;
+  border-radius: 5px;
+  background-color: var(--spice-card);
+  font-size: 13px;
+  color: var(--spice-subtext);
+}
+
+.guessMark {
+  flex: 0 0 auto;
+  width: 13px;
+  text-align: center;
+}
+
+.guessText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skipped .guessText {
+  font-style: italic;
+  opacity: 0.75;
+}
+
+.correct {
+  background-color: color-mix(in srgb, var(--spice-button) 18%, var(--spice-card));
+  color: var(--spice-text);
+  font-weight: 700;
+
+  .guessMark {
+    color: var(--spice-button);
   }
 }
 
@@ -77,10 +129,22 @@
   gap: 20px;
 }
 
+// The button stylesheet is bundled after this one, so .button wins any property
+// it also sets regardless of what we do here - hence !important on exactly the
+// two it fights us over, and nothing else.
 .StatsButton {
-  color: var(--spice-text) !important;
-  background-color: transparent !important;
-  padding: 12px !important;
+  flex: 0 0 auto;
+  display: inline-flex !important;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none !important;
+}
+
+// Underline the label rather than the whole control, so the rule does not run
+// under the icon as well.
+.statsLabel {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 :global(body.name-that-tune.name-that-tune--guessing) .container {

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -11,6 +11,11 @@
     "skipped": "Omès",
     "giveUp": "Rendir-se i revelar",
     "nextSong": "Següent cançó",
+    "reveal": {
+      "wonIn": "Encertat en {{count}}",
+      "gaveUpAfter": "Rendit després de {{count}}",
+      "playingInFull": "Reproduint sencera"
+    },
     "menuEntry": "Reproduïr $t(appName)",
     "sendingURIs_one": "Enviant {{count}} URI a $t(appName)",
     "sendingURIs_other": "Enviant {{count}} URIs a $t(appName)",

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Reproduïr {{count}}s",
     "guessBtn": "Esbrinar",
     "skipBtn": "Saltar +{{count}}s",
-    "giveUp": "Rendir-se",
+    "giveUp": "Rendir-se i revelar",
     "nextSong": "Següent cançó",
     "menuEntry": "Reproduïr $t(appName)",
     "sendingURIs_one": "Enviant {{count}} URI a $t(appName)",

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Anomena la cançó",
     "title": "🎵 $t(appName)",
-    "winMsg": "Has guanyat!",
     "guessPlaceholder": "Esbrinar la cançó",
     "suggestionsLabel": "Suggeriments des cançons",
     "playXSeconds": "Reproduïr {{count}}s",

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Suggeriments des cançons",
     "playXSeconds": "Reproduïr {{count}}s",
     "guessBtn": "Esbrinar",
-    "skipBtn": "Saltar",
+    "skipBtn": "Saltar +{{count}}s",
     "giveUp": "Rendir-se",
     "nextSong": "Següent cançó",
     "menuEntry": "Reproduïr $t(appName)",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Errate den Titel!",
     "title": "🎵 $t(appName)",
-    "winMsg": "Das war richtig!",
     "guessPlaceholder": "Rate den Titel",
     "suggestionsLabel": "Titelvorschläge",
 	  "playXSeconds": "Spiele {{count}}s ab",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -8,7 +8,7 @@
 	  "playXSeconds": "Spiele {{count}}s ab",
     "guessBtn": "Raten",
     "skipBtn": "Überspringen +{{count}}s",
-    "giveUp": "Aufgeben",
+    "giveUp": "Aufgeben und auflösen",
     "nextSong": "Nächster Titel",
     "menuEntry": "Spiele $t(appName)",
     "sendingURIs_one": "Sende {{count}} URI an $t(appName)",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -11,6 +11,11 @@
     "skipped": "Übersprungen",
     "giveUp": "Aufgeben und auflösen",
     "nextSong": "Nächster Titel",
+    "reveal": {
+      "wonIn": "In {{count}} erraten",
+      "gaveUpAfter": "Nach {{count}} aufgegeben",
+      "playingInFull": "Wird vollständig abgespielt"
+    },
     "menuEntry": "Spiele $t(appName)",
     "sendingURIs_one": "Sende {{count}} URI an $t(appName)",
     "sendingURIs_other": "Sende {{count}} URIs an $t(appName)",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Titelvorschläge",
 	  "playXSeconds": "Spiele {{count}}s ab",
     "guessBtn": "Raten",
-    "skipBtn": "Überspringen",
+    "skipBtn": "Überspringen +{{count}}s",
     "giveUp": "Aufgeben",
     "nextSong": "Nächster Titel",
     "menuEntry": "Spiele $t(appName)",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Ονομάστε αυτή τη μελωδία",
     "title": "🎵 $t(appName)",
-    "winMsg": "Κέρδισες!",
     "guessPlaceholder": "Βρες το Τραγούδι",
     "suggestionsLabel": "Προτάσεις τραγουδιών",
     "playXSeconds": "Παίξε {{count}}s",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Προτάσεις τραγουδιών",
     "playXSeconds": "Παίξε {{count}}s",
     "guessBtn": "Μάντεψε",
-    "skipBtn": "Παράλειψη",
+    "skipBtn": "Παράλειψη +{{count}}s",
     "giveUp": "Παραιτούμαι",
     "nextSong": "Επόμενο τραγούδι",
     "menuEntry": "Παίξε $t(appName)",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Παίξε {{count}}s",
     "guessBtn": "Μάντεψε",
     "skipBtn": "Παράλειψη +{{count}}s",
-    "giveUp": "Παραιτούμαι",
+    "giveUp": "Παραιτούμαι και αποκαλύπτω",
     "nextSong": "Επόμενο τραγούδι",
     "menuEntry": "Παίξε $t(appName)",
     "sendingURIs_one": "Αποστολή {{count}} URI σε $t(appName)",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -11,6 +11,11 @@
     "skipped": "Παραλείφθηκε",
     "giveUp": "Παραιτούμαι και αποκαλύπτω",
     "nextSong": "Επόμενο τραγούδι",
+    "reveal": {
+      "wonIn": "Το βρήκες σε {{count}}",
+      "gaveUpAfter": "Παραιτήθηκες μετά από {{count}}",
+      "playingInFull": "Αναπαράγεται ολόκληρο"
+    },
     "menuEntry": "Παίξε $t(appName)",
     "sendingURIs_one": "Αποστολή {{count}} URI σε $t(appName)",
     "sendingURIs_other": "Αποστολή {{count}} URIs σε $t(appName)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Name That Tune",
     "title": "🎵 $t(appName)",
-    "winMsg": "You won!",
     "guessPlaceholder": "Guess the song",
     "suggestionsLabel": "Song suggestions",
     "playXSeconds": "Play {{count}}s",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Song suggestions",
     "playXSeconds": "Play {{count}}s",
     "guessBtn": "Guess",
-    "skipBtn": "Skip",
+    "skipBtn": "Skip +{{count}}s",
     "giveUp": "Give up",
     "nextSong": "Next song",
     "menuEntry": "Play $t(appName)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Play {{count}}s",
     "guessBtn": "Guess",
     "skipBtn": "Skip +{{count}}s",
-    "giveUp": "Give up",
+    "giveUp": "Give up and reveal",
     "nextSong": "Next song",
     "menuEntry": "Play $t(appName)",
     "sendingURIs_one": "Sending {{count}} URI to $t(appName)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,6 +11,11 @@
     "skipped": "Skipped",
     "giveUp": "Give up and reveal",
     "nextSong": "Next song",
+    "reveal": {
+      "wonIn": "Got it in {{count}}",
+      "gaveUpAfter": "Gave up after {{count}}",
+      "playingInFull": "Playing in full"
+    },
     "menuEntry": "Play $t(appName)",
     "sendingURIs_one": "Sending {{count}} URI to $t(appName)",
     "sendingURIs_other": "Sending {{count}} URIs to $t(appName)",

--- a/src/locales/es-419.json
+++ b/src/locales/es-419.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Sugerencias de canciones",
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
-    "skipBtn": "Saltar",
+    "skipBtn": "Saltar +{{count}}s",
     "giveUp": "Rendirse",
     "nextSong": "Siguiente Canción",
     "menuEntry": "Reproducir $t(appName)",

--- a/src/locales/es-419.json
+++ b/src/locales/es-419.json
@@ -11,6 +11,11 @@
     "skipped": "Omitido",
     "giveUp": "Rendirse y revelar",
     "nextSong": "Siguiente Canción",
+    "reveal": {
+      "wonIn": "Acertada en {{count}}",
+      "gaveUpAfter": "Te rendiste tras {{count}}",
+      "playingInFull": "Reproduciendo completa"
+    },
     "menuEntry": "Reproducir $t(appName)",
     "sendingURIs_one": "Enviando {{count}} URI a $t(appName)",
     "sendingURIs_other": "Enviando {{count}} URIs a $t(appName)",

--- a/src/locales/es-419.json
+++ b/src/locales/es-419.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
     "skipBtn": "Saltar +{{count}}s",
-    "giveUp": "Rendirse",
+    "giveUp": "Rendirse y revelar",
     "nextSong": "Siguiente Canción",
     "menuEntry": "Reproducir $t(appName)",
     "sendingURIs_one": "Enviando {{count}} URI a $t(appName)",

--- a/src/locales/es-419.json
+++ b/src/locales/es-419.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Nombra la Rola",
     "title": "🎵 $t(appName)",
-    "winMsg": "Ganaste!",
     "guessPlaceholder": "Adivina la canción",
     "suggestionsLabel": "Sugerencias de canciones",
     "playXSeconds": "Reproducir {{count}}s",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Adivina la Canción",
     "title": "🎵 $t(appName)",
-    "winMsg": "¡Correcto!",
     "guessPlaceholder": "Adivina la canción",
     "suggestionsLabel": "Sugerencias de canciones",
     "playXSeconds": "Reproducir {{count}}s",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -11,6 +11,11 @@
     "skipped": "Omitido",
     "giveUp": "Rendirse y revelar",
     "nextSong": "Siguiente canción",
+    "reveal": {
+      "wonIn": "Acertada en {{count}}",
+      "gaveUpAfter": "Te rendiste tras {{count}}",
+      "playingInFull": "Reproduciendo completa"
+    },
     "menuEntry": "Juega a $t(appName)",
     "sendingURIs_one": "Enviando {{count}} URI a $t(appName)",
     "sendingURIs_other": "Enviando {{count}} URIs a $t(appName)",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Sugerencias de canciones",
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
-    "skipBtn": "Saltar",
+    "skipBtn": "Saltar +{{count}}s",
     "giveUp": "Rendirse",
     "nextSong": "Siguiente canción",
     "menuEntry": "Juega a $t(appName)",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
     "skipBtn": "Saltar +{{count}}s",
-    "giveUp": "Rendirse",
+    "giveUp": "Rendirse y revelar",
     "nextSong": "Siguiente canción",
     "menuEntry": "Juega a $t(appName)",
     "sendingURIs_one": "Enviando {{count}} URI a $t(appName)",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -11,6 +11,11 @@
     "skipped": "Passé",
     "giveUp": "Abandonner et révéler",
     "nextSong": "Chanson suivante",
+    "reveal": {
+      "wonIn": "Trouvé en {{count}}",
+      "gaveUpAfter": "Abandonné après {{count}}",
+      "playingInFull": "Lecture complète"
+    },
     "menuEntry": "Jouer à $t(appName)",
     "sendingURIs_one": "Envoi de {{count}} URI à $t(appName)",
     "sendingURIs_other": "Envoi de {{count}} URIs à $t(appName)",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Name That Tune",
     "title": "🎵 $t(appName)",
-    "winMsg": "Vous avez gagné !",
     "guessPlaceholder": "Devinez la chanson",
     "suggestionsLabel": "Suggestions de chansons",
     "playXSeconds": "Jouer à {{count}}s",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Suggestions de chansons",
     "playXSeconds": "Jouer à {{count}}s",
     "guessBtn": "Devinez",
-    "skipBtn": "Passer",
+    "skipBtn": "Passer +{{count}}s",
     "giveUp": "Abandonner",
     "nextSong": "Chanson suivante",
     "menuEntry": "Jouer à $t(appName)",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Jouer à {{count}}s",
     "guessBtn": "Devinez",
     "skipBtn": "Passer +{{count}}s",
-    "giveUp": "Abandonner",
+    "giveUp": "Abandonner et révéler",
     "nextSong": "Chanson suivante",
     "menuEntry": "Jouer à $t(appName)",
     "sendingURIs_one": "Envoi de {{count}} URI à $t(appName)",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Sugestie utworów",
     "playXSeconds": "Odtwórz {{count}}s",
     "guessBtn": "Zgadnij",
-    "skipBtn": "Pomiń",
+    "skipBtn": "Pomiń +{{count}}s",
     "giveUp": "Poddaj się",
     "nextSong": "Następna piosenka",
     "menuEntry": "Zagraj w $t(appName)",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -11,6 +11,11 @@
     "skipped": "Pominięto",
     "giveUp": "Poddaj się i pokaż",
     "nextSong": "Następna piosenka",
+    "reveal": {
+      "wonIn": "Zgadnięto w {{count}}",
+      "gaveUpAfter": "Poddano się po {{count}}",
+      "playingInFull": "Odtwarzanie w całości"
+    },
     "menuEntry": "Zagraj w $t(appName)",
     "sendingURIs_one": "Wysyłanie {{count}} linku do $t(appName)",
     "sendingURIs_few": "Wysyłanie {{count}} linków do $t(appName)",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Jaka To Melodia",
     "title": "🎵 $t(appName)",
-    "winMsg": "Wygrałeś!",
     "guessPlaceholder": "Zgadnij tytuł",
     "suggestionsLabel": "Sugestie utworów",
     "playXSeconds": "Odtwórz {{count}}s",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Odtwórz {{count}}s",
     "guessBtn": "Zgadnij",
     "skipBtn": "Pomiń +{{count}}s",
-    "giveUp": "Poddaj się",
+    "giveUp": "Poddaj się i pokaż",
     "nextSong": "Następna piosenka",
     "menuEntry": "Zagraj w $t(appName)",
     "sendingURIs_one": "Wysyłanie {{count}} linku do $t(appName)",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Sugestões de músicas",
     "playXSeconds": "Tocar {{count}}s",
     "guessBtn": "Adivinhar",
-    "skipBtn": "Mais Tempo",
+    "skipBtn": "Mais Tempo +{{count}}s",
     "giveUp": "Desistir",
     "nextSong": "Próxima música",
     "menuEntry": "Jogar $t(appName)",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -11,6 +11,11 @@
     "skipped": "Pulado",
     "giveUp": "Desistir e revelar",
     "nextSong": "Próxima música",
+    "reveal": {
+      "wonIn": "Acertou em {{count}}",
+      "gaveUpAfter": "Desistiu após {{count}}",
+      "playingInFull": "Tocando completa"
+    },
     "menuEntry": "Jogar $t(appName)",
     "sendingURIs_one": "Enviando{{count}} URI para $t(appName)",
     "sendingURIs_other": "Enviando {{count}} URIs para $t(appName)",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Descubra a música",
     "title": "🎵 $t(appName)",
-    "winMsg": "Você acertou!",
     "guessPlaceholder": "Adivinhe a música",
     "suggestionsLabel": "Sugestões de músicas",
     "playXSeconds": "Tocar {{count}}s",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Tocar {{count}}s",
     "guessBtn": "Adivinhar",
     "skipBtn": "Mais Tempo +{{count}}s",
-    "giveUp": "Desistir",
+    "giveUp": "Desistir e revelar",
     "nextSong": "Próxima música",
     "menuEntry": "Jogar $t(appName)",
     "sendingURIs_one": "Enviando{{count}} URI para $t(appName)",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -2,7 +2,6 @@
   "translation": {
     "appName": "Вгадай Мелодію",
     "title": "🎵 $t(appName)",
-    "winMsg": "Ви перемогли!",
     "guessPlaceholder": "Назва пісні",
     "suggestionsLabel": "Пропозиції пісень",
     "playXSeconds": "Слухати {{count}}с",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -11,6 +11,11 @@
     "skipped": "Пропущено",
     "giveUp": "Здатись і показати",
     "nextSong": "Наступна пісня",
+    "reveal": {
+      "wonIn": "Вгадано за {{count}}",
+      "gaveUpAfter": "Здались після {{count}}",
+      "playingInFull": "Відтворюється повністю"
+    },
     "menuEntry": "Грати у $t(appName)",
     "sendingURIs_one": "Відправка {{count}} URI до $t(appName)",
     "sendingURIs_other": "Відправка {{count}} URIs до $t(appName)",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -8,7 +8,7 @@
     "playXSeconds": "Слухати {{count}}с",
     "guessBtn": "Вгадати",
     "skipBtn": "Пропустити +{{count}}с",
-    "giveUp": "Здатись",
+    "giveUp": "Здатись і показати",
     "nextSong": "Наступна пісня",
     "menuEntry": "Грати у $t(appName)",
     "sendingURIs_one": "Відправка {{count}} URI до $t(appName)",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -7,7 +7,7 @@
     "suggestionsLabel": "Пропозиції пісень",
     "playXSeconds": "Слухати {{count}}с",
     "guessBtn": "Вгадати",
-    "skipBtn": "Пропустити",
+    "skipBtn": "Пропустити +{{count}}с",
     "giveUp": "Здатись",
     "nextSong": "Наступна пісня",
     "menuEntry": "Грати у $t(appName)",

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -5,6 +5,7 @@ import { TFunction } from 'i18next';
 
 import GuessItem from '../components/GuessItem';
 import Button from '../components/Button';
+import Reveal from '../components/Reveal';
 import TrackSuggestions from '../components/TrackSuggestions';
 
 import {
@@ -310,6 +311,21 @@ class Game extends React.Component<
         ? `${TRACK_SUGGESTIONS_LISTBOX_ID}-option-${this.state.highlightedIndex}`
         : undefined;
 
+    // Shown in both states, but in different company: under the controls while
+    // guessing, under the reveal once the round is over.
+    const guessList = (
+      <ol className={styles.guessList}>
+        {this.state.guesses.map((guess, i) => (
+          <GuessItem
+            key={i}
+            index={i}
+            guesses={this.state.guesses}
+            won={gameWon}
+          />
+        ))}
+      </ol>
+    );
+
     return (
       <>
         <div className={styles.container}>
@@ -336,90 +352,86 @@ class Game extends React.Component<
             </Button>
           </header>
 
-          {gameWon ? (
-            <h2 className={styles.subtitle}>{t('winMsg')}</h2>
-          ) : null}
-
-          <form
-            className={styles.guessForm}
-            onSubmit={this.submitGuess}
-          >
-            <div className={styles.inputContainer}>
-              <input
-                type={'text'}
-                className={styles.input}
-                placeholder={t('guessPlaceholder') as string}
-                value={this.state.guess}
-                disabled={!isPlaying}
-                onChange={this.guessChange}
-                onKeyDown={this.guessKeyDown}
-                onBlur={this.closeSuggestions}
-                autoComplete="off"
-                role="combobox"
-                aria-autocomplete="list"
-                aria-expanded={suggestionsOpen}
-                aria-controls={
-                  suggestionsOpen
-                    ? TRACK_SUGGESTIONS_LISTBOX_ID
-                    : undefined
-                }
-                aria-activedescendant={activeSuggestionId}
-              />
-
-              <TrackSuggestions
-                listboxId={TRACK_SUGGESTIONS_LISTBOX_ID}
-                label={t('suggestionsLabel')}
-                suggestions={this.state.suggestions}
-                highlightedIndex={this.state.highlightedIndex}
-                onSelect={this.selectSuggestion}
-              />
-            </div>
-
-            <div className={styles.formButtonContainer}>
-              <Button
-                variant={'primary'}
-                classes={[styles.guessButton]}
-                onClick={() => this.submitGuess()}
-                disabled={!isPlaying}
-              >
-                {t('guessBtn')}
-              </Button>
-
-              <Button
-                variant={'secondary'}
-                onClick={this.skipGuess}
-                disabled={!isPlaying}
-              >
-                {t('skipBtn', { count: skipCost })}
-              </Button>
-            </div>
-          </form>
-
           {isPlaying ? (
-            <Button onClick={this.playClick}>
-              {t('playXSeconds', {
-                count: stageToTime(this.state.stage),
-              })}
-            </Button>
-          ) : null}
+            <>
+              <form
+                className={styles.guessForm}
+                onSubmit={this.submitGuess}
+              >
+                <div className={styles.inputContainer}>
+                  <input
+                    type={'text'}
+                    className={styles.input}
+                    placeholder={t('guessPlaceholder') as string}
+                    value={this.state.guess}
+                    onChange={this.guessChange}
+                    onKeyDown={this.guessKeyDown}
+                    onBlur={this.closeSuggestions}
+                    autoComplete="off"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-expanded={suggestionsOpen}
+                    aria-controls={
+                      suggestionsOpen
+                        ? TRACK_SUGGESTIONS_LISTBOX_ID
+                        : undefined
+                    }
+                    aria-activedescendant={activeSuggestionId}
+                  />
 
-          <ol className={styles.guessList}>
-            {this.state.guesses.map((guess, i) => (
-              <GuessItem
-                key={i}
-                index={i}
-                guesses={this.state.guesses}
+                  <TrackSuggestions
+                    listboxId={TRACK_SUGGESTIONS_LISTBOX_ID}
+                    label={t('suggestionsLabel')}
+                    suggestions={this.state.suggestions}
+                    highlightedIndex={this.state.highlightedIndex}
+                    onSelect={this.selectSuggestion}
+                  />
+                </div>
+
+                <div className={styles.formButtonContainer}>
+                  <Button
+                    variant={'primary'}
+                    classes={[styles.guessButton]}
+                    onClick={() => this.submitGuess()}
+                  >
+                    {t('guessBtn')}
+                  </Button>
+
+                  <Button
+                    variant={'secondary'}
+                    onClick={this.skipGuess}
+                  >
+                    {t('skipBtn', { count: skipCost })}
+                  </Button>
+                </div>
+              </form>
+
+              <Button onClick={this.playClick}>
+                {t('playXSeconds', {
+                  count: stageToTime(this.state.stage),
+                })}
+              </Button>
+
+              {guessList}
+
+              <Button variant={'tertiary'} onClick={this.giveUp}>
+                {t('giveUp')}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Reveal
                 won={gameWon}
+                attempts={this.state.guesses.length}
               />
-            ))}
-          </ol>
 
-          <Button
-            variant={isPlaying ? 'tertiary' : 'primary'}
-            onClick={isPlaying ? this.giveUp : this.nextSong}
-          >
-            {isPlaying ? t('giveUp') : t('nextSong')}
-          </Button>
+              <Button variant={'primary'} onClick={this.nextSong}>
+                {t('nextSong')}
+              </Button>
+
+              {guessList}
+            </>
+          )}
         </div>
       </>
     );

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -378,6 +378,7 @@ class Game extends React.Component<
             <div className={styles.formButtonContainer}>
               <Button
                 variant={'primary'}
+                classes={[styles.guessButton]}
                 onClick={() => this.submitGuess()}
                 disabled={!isPlaying}
               >

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -300,6 +300,11 @@ class Game extends React.Component<
 
     const suggestionsOpen = this.state.suggestions.length > 0;
 
+    // What a skip actually buys you, so the button can price itself. Derived
+    // from the curve rather than hardcoded, so it stays right if that changes.
+    const skipCost =
+      stageToTime(this.state.stage + 1) - stageToTime(this.state.stage);
+
     const activeSuggestionId =
       this.state.highlightedIndex >= 0
         ? `${TRACK_SUGGESTIONS_LISTBOX_ID}-option-${this.state.highlightedIndex}`
@@ -308,7 +313,28 @@ class Game extends React.Component<
     return (
       <>
         <div className={styles.container}>
-          <h1 className={styles.title}>{t('title')}</h1>
+          <header className={styles.header}>
+            <h1 className={styles.title}>{t('title')}</h1>
+
+            <Button
+              variant={'tertiary'}
+              onClick={this.goToStats}
+              classes={[styles.StatsButton]}
+            >
+              <svg
+                width={16}
+                height={16}
+                viewBox={'0 0 24 24'}
+                fill={'currentColor'}
+                aria-hidden={true}
+              >
+                <rect x={3} y={12} width={4} height={9} rx={1} />
+                <rect x={10} y={7} width={4} height={14} rx={1} />
+                <rect x={17} y={3} width={4} height={18} rx={1} />
+              </svg>
+              <span className={styles.statsLabel}>{t('stats.title')}</span>
+            </Button>
+          </header>
 
           {gameWon ? (
             <h2 className={styles.subtitle}>{t('winMsg')}</h2>
@@ -351,6 +377,7 @@ class Game extends React.Component<
 
             <div className={styles.formButtonContainer}>
               <Button
+                variant={'primary'}
                 onClick={() => this.submitGuess()}
                 disabled={!isPlaying}
               >
@@ -358,10 +385,11 @@ class Game extends React.Component<
               </Button>
 
               <Button
+                variant={'secondary'}
                 onClick={this.skipGuess}
                 disabled={!isPlaying}
               >
-                {t('skipBtn')}
+                {t('skipBtn', { count: skipCost })}
               </Button>
             </div>
           </form>
@@ -373,10 +401,6 @@ class Game extends React.Component<
               })}
             </Button>
           ) : null}
-
-          <Button onClick={isPlaying ? this.giveUp : this.nextSong}>
-            {isPlaying ? t('giveUp') : t('nextSong')}
-          </Button>
 
           <ol className={styles.guessList}>
             {this.state.guesses.map((guess, i) => (
@@ -390,10 +414,10 @@ class Game extends React.Component<
           </ol>
 
           <Button
-            onClick={this.goToStats}
-            classes={[styles.StatsButton]}
+            variant={isPlaying ? 'tertiary' : 'primary'}
+            onClick={isPlaying ? this.giveUp : this.nextSong}
           >
-            {t('stats.title')}
+            {isPlaying ? t('giveUp') : t('nextSong')}
           </Button>
         </div>
       </>


### PR DESCRIPTION
## Summary

A design pass on the game screen, plus a reveal for the end of a round. Nine commits, three of them merges from `main`.

Every control used to be the same filled white pill, so "give up" shouted as loudly as "guess" and the only way to tell them apart was to read them. `Button` takes a `variant` prop — the default stays the original pill, so nothing outside the game moves — and the game assigns one per role:

| Control | Variant | Why |
|---|---|---|
| Guess | primary, filled `--spice-button` | The one thing you're here to do. The only green on the screen. |
| Skip | secondary, outlined | A real alternative, not a lesser Guess. |
| Play | neutral, unchanged | Playback, not form submission. |
| Give up | tertiary, small underlined text | Rare and one-way. Findable, not tempting. |
| Next song | primary | Once a round ends it is the only thing left to do. |

**Guess and skip share a full-width row**, guess taking the remaining space and skip beside it at its natural width.

**Skip prices itself.** `Skip +3s` rather than `Skip`. The number is the delta to the next stage, derived from `stageToTime` rather than hardcoded, so it stays right if the curve changes. It works out to `stage + 1`.

**"Give up" became "Give up and reveal"**, which says what the control does — it reveals the answer and plays the song in full, rather than only ending the round.

**Wrong guesses are attempts, not errors.** The list drops `--spice-notification-error` red for neutral rows on `--spice-card`, with the marker carrying the meaning and green spent only on the correct one. Skips get an en dash and italics so they read as distinct at a glance.

**Stats moved into a header row** alongside the title, instead of floating at the bottom of the stack where it drifted further down with every guess. The title drops from 50px to 22px to sit in that row.

## The reveal

Winning printed "You won!", and the answer only became visible because the guessing body class dropped and Spotify's own now-playing bar came back — the best moment in the game happened in someone else's UI. Both end states now show the same card: artwork, how it went, the track and its artists, and "next song" as the primary action. Losing adds "playing in full", since that is what giving up does.

Artwork comes from `metadata.image_xlarge_url`, which Spotify serves as a `spotify:image:` URI rather than https. The client resolves those natively, so no CDN host is hardcoded and there is nothing to rot. Artists come from `item.artists` rather than `metadata.artist_name`, which only carries the first and would drop the second on a collaboration.

The form is **removed** rather than disabled once a round ends. The card carries `aria-live`, since nothing takes focus when a round ends and the result was otherwise silent to a screen reader; the artwork has empty alt text on purpose, because the title sits directly below it.

## Two things worth reading the diff for

**A rendering bug.** "Skipped" rendered as "Skippea". Spotify's UI font ships no italic, so the browser synthesises the slant and the last glyph's ink overhangs its advance width — at 13px, advance 49.57 against an ink right edge of 50.85. The `overflow: hidden` that ellipsises long titles clipped the difference. Upright text has the opposite margin (ink 48.54), which is why only the skipped rows showed it. 2px of trailing padding gives the slant somewhere to land.

**The `!important` pair on `StatsButton`,** which the rest of the file does without. The button stylesheet is bundled *after* the app stylesheet, so `.button` wins any property it also sets — which silently ate `display: inline-flex` and collapsed the icon and label together. They cover exactly `display` and `text-decoration`.

## A commit that no longer fixes anything observable

`fix: stop disabled buttons reacting to hover` is real and correct — `:hover` matches a disabled button where `:active` does not, so all three hover rules now opt out explicitly. It fixed guess and skip growing under the pointer after a round ended.

The later reveal commit then removed the form entirely at round end, so **nothing in the game is disabled any more** — measured across a full round, both end states, and every button in the container: no `disabled` anywhere. The guard is now preventative, protecting the shared `Button` component rather than a reachable state. Keeping it is a judgement call; it is three `:not(:disabled)` selectors and it stops the bug returning the moment anyone disables a button again.

## Testing

Measured in a live 1.2.96.518 client over the debug port, against this branch's build, with stats snapshotted and restored around the run.

Button variants, computed:

| Control | background | colour | size |
|---|---|---|---|
| Guess | `rgb(29, 185, 84)` | `rgb(18, 18, 18)` | 16px |
| Skip | transparent + inset ring | `rgb(255, 255, 255)` | 16px |
| Play | `rgb(255, 255, 255)` | `rgb(18, 18, 18)` | 16px |
| Give up | transparent | `rgb(179, 179, 179)` | 12px |

Guess/skip row at the 420px form width: **281px + 129px with a 10px gap**, filling it exactly.

Skip repricing across a fresh round: `Skip +1s → +2s → +3s → +4s`.

Guess rows: `rgb(179, 179, 179)` on `rgb(40, 40, 40)`, no error red.

The reveal, both states:

| | Lost | Won |
|---|---|---|
| verdict | `Gave up after 4` | `Got it in 1` |
| verdict colour | `rgb(179, 179, 179)` | `rgb(29, 185, 84)` |
| artwork | loaded, 640×640 | loaded, 640×640 |
| `Playing in full` | shown | absent |
| `aria-live` | polite | polite |
| form removed | yes | yes |

Italic clipping, via canvas `actualBoundingBoxRight` — note `Range.getBoundingClientRect` reports the *advance* width and shows nothing wrong here:

| | client width | ink right edge | clipped |
|---|---|---|---|
| before | 50 | 50.85 | 0.85px |
| after | 52 | 50.85 | none |

No raw i18n keys leak into the rendered UI, which is the failure mode for the locale edits below. Answer hiding still works — navigating away and back gives `name-that-tune--guessing` on the body with `.main-nowPlayingBar-left` and `.player-controls__buttons` both at `opacity: 0`.

- `pnpm lint:ci` passes.
- `pnpm type-check` passes.
- `pnpm build:local` succeeds, and the new scoped class names survive minification alongside the existing ones, so this does not disturb the postcss-modules arrangement from #214.

## Wants a second opinion

**36 translation strings across nine locales are mine and unreviewed** — the nine `giveUp` rewrites and the 27 new `reveal.*` keys. Tracked in #223 with a per-language table and the three places I am least confident. Merging this ships them; the alternative is stripping them to English-only first.

**The reveal has only been seen against the stock palette.** The theme from #216 makes `--spice-main` transparent, so album art shows through the game background — which would put artwork behind the reveal card. It may want its own opaque surface rather than trusting the variable.

## Deliberately not here

- The segmented clip bar from the mockup, dropped along with the guess cap.
- The 🎵 emoji in `title`, which would mean editing that key in all ten locales.
- `winMsg` and the `.subtitle` class, which the reveal superseded, are **deleted** rather than left orphaned. The nine community translations stay recoverable from history, and an unused i18n key that nothing flags is a trap for the next person adding a locale.
