### PR TITLE
fix: localize skipped guess labels

### DIFF
--- a/src/components/GuessItem.tsx
+++ b/src/components/GuessItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import styles from '../css/name-that-tune.module.scss';
 
@@ -7,10 +8,11 @@ const GuessItem = (props: {
   won: boolean;
   index: number;
 }) => {
+  const { t } = useTranslation();
   const correct = props.won && (props.index === props.guesses.length - 1);
   return (
     <li className={correct ? styles.correct : undefined}>
-      {correct ? '✔' : 'x'} {props.guesses[props.index] || 'SKIPPED'}
+      {correct ? '✔' : 'x'} {props.guesses[props.index] || t('skipped')}
     </li>
   );
 };

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Reproduïr {{count}}s",
     "guessBtn": "Esbrinar",
     "skipBtn": "Saltar",
+    "skipped": "Omès",
     "giveUp": "Rendir-se",
     "nextSong": "Següent cançó",
     "menuEntry": "Reproduïr $t(appName)",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -8,6 +8,7 @@
 	  "playXSeconds": "Spiele {{count}}s ab",
     "guessBtn": "Raten",
     "skipBtn": "Überspringen",
+    "skipped": "Übersprungen",
     "giveUp": "Aufgeben",
     "nextSong": "Nächster Titel",
     "menuEntry": "Spiele $t(appName)",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Παίξε {{count}}s",
     "guessBtn": "Μάντεψε",
     "skipBtn": "Παράλειψη",
+    "skipped": "Παραλείφθηκε",
     "giveUp": "Παραιτούμαι",
     "nextSong": "Επόμενο τραγούδι",
     "menuEntry": "Παίξε $t(appName)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Play {{count}}s",
     "guessBtn": "Guess",
     "skipBtn": "Skip",
+    "skipped": "Skipped",
     "giveUp": "Give up",
     "nextSong": "Next song",
     "menuEntry": "Play $t(appName)",

--- a/src/locales/es-419.json
+++ b/src/locales/es-419.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
     "skipBtn": "Saltar",
+    "skipped": "Omitido",
     "giveUp": "Rendirse",
     "nextSong": "Siguiente Canción",
     "menuEntry": "Reproducir $t(appName)",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Reproducir {{count}}s",
     "guessBtn": "Adivinar",
     "skipBtn": "Saltar",
+    "skipped": "Omitido",
     "giveUp": "Rendirse",
     "nextSong": "Siguiente canción",
     "menuEntry": "Juega a $t(appName)",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Jouer à {{count}}s",
     "guessBtn": "Devinez",
     "skipBtn": "Passer",
+    "skipped": "Passé",
     "giveUp": "Abandonner",
     "nextSong": "Chanson suivante",
     "menuEntry": "Jouer à $t(appName)",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Odtwórz {{count}}s",
     "guessBtn": "Zgadnij",
     "skipBtn": "Pomiń",
+    "skipped": "Pominięto",
     "giveUp": "Poddaj się",
     "nextSong": "Następna piosenka",
     "menuEntry": "Zagraj w $t(appName)",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Tocar {{count}}s",
     "guessBtn": "Adivinhar",
     "skipBtn": "Mais Tempo",
+    "skipped": "Pulado",
     "giveUp": "Desistir",
     "nextSong": "Próxima música",
     "menuEntry": "Jogar $t(appName)",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -8,6 +8,7 @@
     "playXSeconds": "Слухати {{count}}с",
     "guessBtn": "Вгадати",
     "skipBtn": "Пропустити",
+    "skipped": "Пропущено",
     "giveUp": "Здатись",
     "nextSong": "Наступна пісня",
     "menuEntry": "Грати у $t(appName)",


### PR DESCRIPTION
## Summary

- render the skipped-guess placeholder through i18next instead of a hardcoded English string
- add the `skipped` label to all 10 existing locale files
- keep the marker and layout changes from #219 outside this focused fix

## Validation

- `pnpm lint:ci`
- `pnpm type-check`
- `pnpm build:local`
- parsed every locale file and verified that all 10 contain a non-empty `translation.skipped` value

Closes #218

## AI assistance

OpenAI Codex assisted with implementation and validation. The resulting diff and command output were reviewed before submission.
