### PR TITLE
docs: correct the spicetify-drive apply loop and reload guidance

### DIFF
--- a/.claude/skills/spicetify-drive/SKILL.md
+++ b/.claude/skills/spicetify-drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spicetify-drive
-description: Attach to the running Spotify desktop client over the Chrome DevTools Protocol to inspect or drive it — read Spicetify internals, run real GraphQL requests, measure computed styles and geometry, dispatch real key/mouse/wheel input, and take screenshots. Also covers the build → apply → relaunch → attach loop for testing a Spicetify custom app or extension in the real client. Use when a claim about Spotify's runtime needs verifying rather than guessing (does this GraphQL definition exist, what shape does it return, which element actually receives this click, does this scroll chain), or when the user asks to run, test, or screenshot a Spicetify app in Spotify.
+description: Attach to the running Spotify desktop client over the Chrome DevTools Protocol to inspect or drive it — read Spicetify internals, run real GraphQL requests, measure computed styles and geometry, dispatch real key/mouse/wheel input, and take screenshots. Also covers the build → refresh → reload → attach loop for testing a Spicetify custom app or extension in the real client, including recovering the client when a reload wedges it. Use when a claim about Spotify's runtime needs verifying rather than guessing (does this GraphQL definition exist, what shape does it return, which element actually receives this click, does this scroll chain), or when the user asks to run, test, or screenshot a Spicetify app in Spotify.
 ---
 
 # Driving Spotify over the debug port
@@ -27,7 +27,7 @@ flag on the process, so do not go looking for one.
 curl -s http://127.0.0.1:8088/json | python3 -m json.tool   # find the xpui target
 ```
 
-## Two modes, very different cost
+## Inspecting vs driving
 
 ### Inspect — cheap, do this freely
 
@@ -55,18 +55,102 @@ tree. Check before drawing conclusions:
 ls -la "$(dirname "$(spicetify -c)")/CustomApps/<app>/"
 ```
 
-### Drive — expensive, confirm with the user first
+### Drive — build, refresh, reload
 
-Testing working-tree changes needs the code inside Spotify's xpui, and there is no
-lighter path than a full apply. This **restarts Spotify** and **disturbs playback**.
-Get explicit agreement before running it.
+Testing working-tree changes needs the code inside Spotify's xpui. Three steps,
+and skipping the third is the classic mistake:
 
 ```bash
-pnpm build                       # into the live CustomApps folder
-spicetify apply                  # copies into Spotify.app, then QUITS Spotify
-open -a Spotify                  # apply does NOT relaunch it
-sleep 14                         # let xpui boot before attaching
+pnpm build                 # into the live CustomApps folder
+spicetify refresh -a       # copies CustomApps into Spotify.app; PID unchanged
+                           # then reload the client -- see below
 ```
+
+Spotify keeps running throughout, so playback survives. The reload does blank the
+UI mid-use and can drop the client on the error screen, so say what you are doing
+rather than cycling this repeatedly while the user watches.
+
+**`-a` alone, never combined.** It copies both the app and its extension, because
+this project builds `extension.js` into the CustomApps folder. `-e` is for the
+standalone `Extensions/` directory and does nothing here. Measured by touching the
+sources and watching what lands inside `Spotify.app`: `-a -e` copies **neither**
+while still printing `success`, and `-l` is a `watch` flag that `refresh` quietly
+treats as `-e`.
+
+**Copying the files is not enough, and the failure is silent.** The running
+renderer keeps serving the stylesheet and bundle it already parsed, so measuring
+before a reload measures the **old** build while the correct file sits on disk —
+indistinguishable from a fix that did not work. After reloading, confirm you are
+looking at the new code before you believe any measurement:
+
+```js
+// the rule you just changed, as the client actually has it
+await d.eval(`(() => {
+  for (const s of document.styleSheets) {
+    if (!(s.href || '').includes('<app-name>')) continue;
+    for (const r of s.cssRules) if (/YourClass/.test(r.selectorText || '')) return r.cssText;
+  }
+})()`);
+```
+
+A full apply **is** required after Spotify itself updates: the update replaces
+`Spotify.app` and takes the patch with it, so the custom app stops loading and the
+debug port stops answering. Take a fresh backup in the same breath, because the
+existing one describes the previous Spotify. Apply quits the client and does not
+relaunch it:
+
+```bash
+spicetify backup apply && open -a Spotify && sleep 14
+```
+
+To tell whether the backup matches the installed client — and so whether this has
+already been done — compare the version Spicetify recorded against the running one:
+
+```bash
+grep -A1 '^\[Backup\]' "$(spicetify -c)"      # version = 1.2.96.518.g366879e1
+defaults read /Applications/Spotify.app/Contents/Info.plist CFBundleVersion
+```
+
+`always_enable_devtools` lives in the config and survives the update, but the patch
+that acts on it does not, so the port comes back with the re-apply rather than
+needing `enable-devtools` run again.
+
+## Reloading without wedging the client
+
+**Do not use `location.reload()`.** It regularly drops xpui into Spotify's
+"Something went wrong / Try reloading the page" screen. When that happens the
+whole client is down, not just the app under test: `window.<globalName>` is
+undefined, the main view is empty, and no app `<script>` is present. That reads
+exactly like the app crashing, and will send you debugging code that is fine.
+
+`Page.reload` over CDP does **not** rescue a client already on that screen. What
+does is clicking the dialog's own button. So always health-check after a reload,
+and recover, before measuring anything:
+
+```js
+const reload = async (d) => {
+  await d.send('Page.enable', {}).catch(() => {});
+  await d.send('Page.reload', { ignoreCache: true });
+
+  for (let i = 0; i < 6; i++) {
+    await d.waitFor(`document.readyState === 'complete' ? 1 : 0`, { timeout: 30000 }).catch(() => {});
+    const state = await d.eval(`(() => ({
+      error: document.body.innerText.includes('Something went wrong'),
+      ready: !!(window.Spicetify && Spicetify.Platform),
+    }))()`).catch(() => ({ error: true, ready: false }));
+    if (!state.error && state.ready) return;
+
+    await d.eval(`(() => { const b = [...document.querySelectorAll('button')]
+      .find(b => /reload page/i.test(b.textContent || '')); if (b) b.click(); })()`).catch(() => {});
+    await d.eval(`new Promise(r => setTimeout(r, 6000))`).catch(() => {});
+  }
+  throw new Error('client stuck on the error screen');
+};
+```
+
+Keep the loop. One run of this helper needed four passes and hit the error screen
+twice before coming back, so a single reload and a `sleep` is not equivalent.
+`spicetify restart` is the heavier fallback if it will not recover.
 
 ## Side effects, and putting things back
 
@@ -99,9 +183,12 @@ await d.eval(`(() => { const s = document.documentElement.style;
 await d.eval(`['--spice-main','--spice-text'].forEach(p => document.documentElement.style.removeProperty(p))`);
 ```
 
-## Input gotchas
+## Gotchas
 
-Both of these cost real debugging time. They look like app bugs and are not.
+Every one of these cost real debugging time, and every one presents as a bug in
+the app rather than in the harness. Rule out the harness first.
+
+**Input**
 
 - **Printable characters must be a lone `char` event.** Pairing `char` with a
   `keyDown` that also carries `text` types everything twice — `bohem` arrives as
@@ -109,12 +196,44 @@ Both of these cost real debugging time. They look like app bugs and are not.
 - **Enter needs a real `keyDown` with `text: '\r'`.** A `rawKeyDown` suppresses the
   keypress, so Chromium never runs a form's default submit and the Enter appears
   to do nothing. `d.key('Enter', 13)` handles this.
+- **Dispatch real events, never `el.value = x`.** Spotify's UI is React, and
+  assigning to `value` does not drive a controlled input.
 
-Use real dispatched events, not `el.value = x` — Spotify's UI is React, and
-assigning to `value` does not drive a controlled input.
+**Selectors**
 
-Beware selectors that also match Spotify's own chrome. `input[role=combobox]`
-matches the main search bar; scope to something app-specific.
+- **Spotify's chrome answers to generic selectors.** `input[role=combobox]` is the
+  main search bar, and its design-system class names contain words like
+  `tertiary`, so a `className.includes(...)` filter over every `button` can match
+  its chrome before it reaches yours. Scope to something app-specific.
+- **`[class*=...]` also matches your own longer class names.**
+  `[class*="app__input"]` matches the input *and* its `app__inputContainer`, and
+  the container wins on document order. The symptom is `d.clear()` throwing
+  `TypeError: Illegal invocation`, because the value setter it borrows from
+  `HTMLInputElement.prototype` lands on a `div`. Lead with the tag:
+  `input[class*="app__input"]`.
+- **`d.clickText` matches the full trimmed text, not a prefix.** A label that grew
+  a suffix — `Skip` becoming `Skip +1s` — stops matching, and reads as the button
+  having vanished. Use a structural selector when the label is dynamic.
+
+**Navigation**
+
+- **`History.push` to the route you are already on does not re-fire an extension's
+  `History.listen`.** Body classes the extension owns therefore do not update,
+  which looks like the app failing to set them. Navigate away and back to test
+  that path for real.
+
+**Window state**
+
+- **Wheel events need a visible window; key and click events do not.** Scrolling
+  is handled by the compositor, which stops running when the window is hidden or
+  minimised, so the event neither scrolls nor gets acknowledged and an awaited
+  dispatch hangs forever. Because everything else keeps working, this reads as
+  `d.wheel` alone being broken. `d.wheel` now checks `document.hidden` and says
+  so; bring Spotify to the front for scroll checks:
+
+  ```js
+  await d.eval(`({ hidden: document.hidden, visibility: document.visibilityState })`);
+  ```
 
 ## Driver API
 
@@ -134,18 +253,28 @@ default-exports an async function taking `d`:
 | `d.consoleLines` | captured console output |
 | `d.send(method, params)` | any raw CDP call |
 
+**`d.eval` has no timeout.** It sets `awaitPromise`, so an expression whose promise
+never settles hangs the whole run with no output — and if you piped through `tail`,
+no partial output either, which looks like the client being stuck rather than your
+own probe. Race anything network-bound:
+
+```js
+await d.eval(`Promise.race([
+  Spicetify.GraphQL.Request(Spicetify.GraphQL.Definitions.searchSuggestions, { query: 'test', limit: 5 }),
+  new Promise(r => setTimeout(() => r({ timedOut: true }), 5000)),
+])`);
+```
+
+Log progress with timestamps in any probe that does more than a couple of steps,
+so a hang points at the step rather than the harness.
+
 ## Worked checks
 
 **Does a GraphQL definition exist, and what does it return?** Definitions are
 persisted queries (`{name, operation, sha256Hash, value: null}`) — there is no
-local AST to read, so run it and inspect the response. The server validates
-variables against the stored operation, so a wrong variable set gives
-`HttpResponseError`; different operations take different variables.
-
-```js
-const res = await d.eval(`Spicetify.GraphQL.Request(
-  Spicetify.GraphQL.Definitions.searchSuggestions, { query: 'test', limit: 5 })`);
-```
+local AST to read, so run it and inspect the response, wrapped in the race above.
+The server validates variables against the stored operation, so a wrong variable
+set gives `HttpResponseError`; different operations take different variables.
 
 **Which element really receives a click?** Settles overlay questions that reading
 CSS cannot.
@@ -168,5 +297,5 @@ Quote the measurement, not the impression: "ancestor `scrollTop` went 0 → 12"
 beats "it seems to scroll the page". When a fix is verified, show before and
 after from the same probe.
 
-If the driver itself misbehaves, say so plainly rather than reporting it as an
-app bug — the two input gotchas above both present as the app ignoring input.
+If the harness is what misbehaved, say so rather than reporting it as an app bug —
+and if you have already reported it the other way round, correct it plainly.

--- a/.claude/skills/spicetify-drive/driver.mjs
+++ b/.claude/skills/spicetify-drive/driver.mjs
@@ -163,6 +163,13 @@ const d = {
     await this.eval(`(() => {
       const el = document.querySelector(${JSON.stringify(selector)});
       if (!el) throw new Error('no element matched ' + ${JSON.stringify(selector)});
+      // A [class*=...] selector matches the wrapper as well as the field, and the
+      // wrapper wins on document order. Say so, rather than letting the value
+      // setter below fail with a bare "Illegal invocation".
+      if (!(el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement)) {
+        throw new Error(${JSON.stringify(selector)} + ' matched <' + el.tagName.toLowerCase() +
+          '>, not an input -- lead the selector with the tag');
+      }
       const set = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
       set.call(el, '');
       el.dispatchEvent(new Event('input', { bubbles: true }));
@@ -191,10 +198,28 @@ const d = {
     }
   },
 
-  /** Scroll over an element. Useful for overscroll and scroll-chaining checks. */
+  /**
+   * Scroll over an element. Useful for overscroll and scroll-chaining checks.
+   *
+   * Wheel input is handled by the compositor, which does not run while the
+   * window is hidden -- the event then neither scrolls nor gets acknowledged,
+   * so an awaited dispatch hangs forever. Key and click events are unaffected,
+   * which makes this look like wheel alone being broken. Fail fast instead.
+   */
   async wheel(selector, deltaY, deltaX = 0) {
+    if (await this.eval('document.hidden')) {
+      throw new Error(
+        'the Spotify window is hidden, so wheel events are not processed -- '
+        + 'bring it to the front before scroll checks',
+      );
+    }
     const { x, y } = await boxOf(selector);
-    await send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX, deltaY });
+    await Promise.race([
+      send('Input.dispatchMouseEvent', { type: 'mouseWheel', x, y, deltaX, deltaY }),
+      new Promise((_, reject) => setTimeout(
+        () => reject(new Error('mouseWheel was not acknowledged within 5s')), 5000,
+      )),
+    ]);
   },
 
   async shot(path) {


### PR DESCRIPTION
## Summary

The `spicetify-drive` skill told you to run a full `spicetify apply` to test working-tree changes, which quits Spotify and disturbs playback. It isn't necessary — `spicetify refresh -a` copies into the app bundle with the process untouched. Correcting that turned up several more inaccuracies, and one bug in `driver.mjs`.

### The apply loop

`refresh -a` leaves the Spotify PID unchanged. Apply is still required after **Spotify itself** updates, since that replaces `Spotify.app` and takes the patch with it, so that path is documented with `backup apply` (the existing backup describes the previous Spotify) plus a way to tell whether it has already been done — `config-xpui.ini` records the version it backed up, which can be compared to the installed `CFBundleVersion`.

The flags are worth knowing. Measured by touching the sources and watching what lands inside `Spotify.app`:

| | app CSS/JS | extension |
|---|---|---|
| `refresh -a` | updated | updated |
| `refresh -e` | unchanged | unchanged |
| `refresh -a -e` | **unchanged** | **unchanged** |
| `refresh -l` | unchanged | unchanged |

`-a -e` copies neither while still printing `success`, and `-l` is a `watch` flag that `refresh` quietly treats as `-e`.

### The half that fails silently

Copying is not enough: the running renderer keeps serving the bundle it already parsed, so measuring before a reload measures the **old** build while the correct file sits on disk. That is indistinguishable from a fix that did not work, and caused a wrong diagnosis during #219.

`location.reload()` is not the way to reload — it regularly drops xpui into Spotify's "Something went wrong" screen, which presents as the app under test failing to render (undefined global, empty main view, no app `<script>`) and sends you debugging code that is fine. `Page.reload` does not rescue a client already there; clicking the dialog's own button does. The skill now carries a health-checking reload helper, verified end to end — it needed four passes and hit the error screen twice, so the retry loop is load-bearing rather than defensive.

### Wheel events need a visible window

Scrolling goes through the compositor, which stops running when the window is hidden. The event then neither scrolls nor gets acknowledged, so an awaited dispatch hangs forever — while key and click events keep working, making it read as `d.wheel` alone being broken. `d.wheel` now checks `document.hidden` and fails in 4ms with that explanation instead of blocking 5s per call on an ack that never comes.

### Also documented, each after reproducing it

- `[class*=...]` selectors match your own wrapper class too, and the container wins on document order — the cause of `d.clear` reporting `Illegal invocation`
- `d.clickText` matches the full trimmed text, so a label gaining a suffix reads as the button vanishing
- `History.push` to the current route does not re-fire an extension's `History.listen`
- Spotify's own design-system class names contain words like `tertiary`, so `className.includes(...)` filters catch its chrome
- `d.eval` has no timeout, so an unsettled promise hangs a run silently

### driver.mjs

Two error-message fixes, no behaviour change on the happy path: `d.clear` names the tag it actually matched, and `d.wheel` fails fast on a hidden window.

## Testing

29 checks against the live 1.2.96.518 client, plus 15 covering the environment and CLI claims. All pass.

Every pre-existing claim was re-verified rather than assumed, including by reproducing the failure each one warns about:

| Claim | How it was confirmed |
|---|---|
| `char` + `keyDown` with `text` doubles input | typed the wrong way on purpose → `"abc"` arrived as `"aabbcc"` |
| `rawKeyDown` Enter suppresses submit | guess count `0 → 0`; `d.key('Enter', 13)` then gave `0 → 1` |
| `el.value = x` does not drive React | DOM value set, React state still empty, submit blocked |
| `input[role=combobox]` hits Spotify chrome | 2 matches, 1 outside the app |
| definitions are persisted queries | keys `name, operation, sha256Hash, value`, `value === null` |
| overscroll does not chain | dropdown `0 → 166`, all 13 ancestors unchanged |

The port, devtools flag, absence of `--remote-debugging-port`, every `spicetify` subcommand referenced, both version-check commands, and every code snippet in the file were run as written.

## Note

The one check that cannot pass unattended is the scroll-chaining one, since it needs the Spotify window frontmost — which is the finding it documents.
