### PR TITLE
fix: describe Spotify's error boundary correctly in spicetify-drive

### DIFF
--- a/.claude/skills/spicetify-drive/SKILL.md
+++ b/.claude/skills/spicetify-drive/SKILL.md
@@ -117,11 +117,12 @@ needing `enable-devtools` run again.
 
 ## Reloading, and Spotify's error boundary
 
-"Something went wrong / Try reloading the page" is **a route-level error boundary
-inside the main view, not a dead client.** The node lives under
-`MAIN` inside `.Root__main-view`; the library sidebar, top bar and player keep
-working, and `Spicetify.Platform` stays available throughout. So `Spicetify`
-being present proves nothing, and neither does the chrome looking fine.
+"Something went wrong / Try reloading the page" is usually **a route-level error
+boundary inside the main view, not a dead client.** The node lives under `MAIN`
+inside `.Root__main-view`; the library sidebar, top bar and player keep working,
+and `Spicetify.Platform` stays available throughout. So `Spicetify` being present
+proves nothing, and neither does the chrome looking fine. The worse variant — the
+client never finishing boot at all — is covered further down.
 
 Two consequences that cost real time:
 
@@ -158,11 +159,52 @@ const reload = async (d, safeRoute = '/collection/tracks') => {
 
 Then navigate to the app route and confirm it mounted, rather than assuming.
 
-The trigger is not the reload API. `location.reload()` and CDP `Page.reload`
-both produce it; reloading a healthy client parked on a good route is fine and
-was done repeatedly without incident. Every occurrence followed a reload landing
-on the app's own route around a `pnpm build` + `spicetify refresh -a`, so treat a
-bundle swap as the risky moment and let the copy settle before reloading.
+### Why it happens, and why it is an app bug
+
+The trigger is not the reload API and not a rebuild. `location.reload()` and CDP
+`Page.reload` both produce it, no build or `refresh` is needed, and reloading a
+healthy client parked on some other route is fine. What matters is **which route
+is active when you reload**: Spotify restores the last route on startup, so
+reloading while the custom app is open makes Spotify load the app bundle *during
+its own boot* rather than on navigation.
+
+Custom app bundles are usually written assuming the opposite. `Spicetify.React`,
+`Spicetify.ReactDOM` and `Spicetify.Locale` do not exist for the first few
+hundred milliseconds, and a bundle that touches any of them at module scope
+throws when it is loaded that early. Measured on a failing boot:
+
+```
+app <script> tag appears at 762ms
+Spicetify.Locale.getLocale     never became available
+the app's global               never appeared
+```
+
+So the module never finished evaluating, and Spicetify's own initialisation
+stalled behind it — `.Root__main-view` never rendered at all.
+
+That means the symptom varies, which is what makes it confusing:
+
+- sometimes the chrome renders and only the app's route shows the boundary
+- sometimes the client never finishes booting, with no main view and no
+  `Spicetify.Locale`
+
+A stalled boot does not recover by reloading; quit and relaunch Spotify.
+
+The durable fix belongs in the app, not the harness: gate the bundle the way
+Spicetify extensions are already gated, so it waits for the globals rather than
+assuming them.
+
+```js
+(async function () {
+  while (!Spicetify.React || !Spicetify.ReactDOM || !Spicetify.Locale) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  // ... bundle ...
+})();
+```
+
+Until a project does that, treat "reload while the app route is open" as the
+thing to avoid, and park elsewhere first.
 
 `spicetify restart` is the heavier fallback — but it **quits Spotify without
 relaunching it**, so follow it with `open -a Spotify` and wait for the port.

--- a/.claude/skills/spicetify-drive/SKILL.md
+++ b/.claude/skills/spicetify-drive/SKILL.md
@@ -159,52 +159,40 @@ const reload = async (d, safeRoute = '/collection/tracks') => {
 
 Then navigate to the app route and confirm it mounted, rather than assuming.
 
-### Why it happens, and why it is an app bug
+### What actually triggers it
 
-The trigger is not the reload API and not a rebuild. `location.reload()` and CDP
-`Page.reload` both produce it, no build or `refresh` is needed, and reloading a
-healthy client parked on some other route is fine. What matters is **which route
-is active when you reload**: Spotify restores the last route on startup, so
-reloading while the custom app is open makes Spotify load the app bundle *during
-its own boot* rather than on navigation.
+Not the reload API, and not a rebuild. `location.reload()` and CDP `Page.reload`
+both produce it, and no build or `refresh` is needed. What matters is **which
+route is active when you reload**, because Spotify restores the last route on
+startup.
 
-Custom app bundles are usually written assuming the opposite. `Spicetify.React`,
-`Spicetify.ReactDOM` and `Spicetify.Locale` do not exist for the first few
-hundred milliseconds, and a bundle that touches any of them at module scope
-throws when it is loaded that early. Measured on a failing boot:
+Measured, five reloads per condition on one machine:
 
-```
-app <script> tag appears at 762ms
-Spicetify.Locale.getLocale     never became available
-the app's global               never appeared
-```
+| reloading while parked on | came back healthy |
+|---|---|
+| a stock Spotify route (`/collection/tracks`) | 4 / 4 |
+| Marketplace — a different Spicetify custom app | 3 / 4 |
+| the app under test | 3 / 5 |
 
-So the module never finished evaluating, and Spicetify's own initialisation
-stalled behind it — `.Root__main-view` never rendered at all.
+**Marketplace fails the same way**, which is the part that matters: this is not
+one app's bundle misbehaving, it is restoring *any* Spicetify custom-app route on
+startup. Do not go hunting in your own code for it.
 
-That means the symptom varies, which is what makes it confusing:
+The symptom varies, which is what makes it confusing:
 
 - sometimes the chrome renders and only the app's route shows the boundary
-- sometimes the client never finishes booting, with no main view and no
-  `Spicetify.Locale`
+- sometimes the client never finishes booting, with no `.Root__main-view` and no
+  `Spicetify.Locale` — a state no amount of reloading recovers, because each
+  reload restores the same route. Quit and relaunch Spotify.
 
-A stalled boot does not recover by reloading; quit and relaunch Spotify.
+So the mitigation is the same either way: **park on a stock route before
+reloading**, which is what the helper above does.
 
-The durable fix belongs in the app, not the harness: gate the bundle the way
-Spicetify extensions are already gated, so it waits for the globals rather than
-assuming them.
-
-```js
-(async function () {
-  while (!Spicetify.React || !Spicetify.ReactDOM || !Spicetify.Locale) {
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  // ... bundle ...
-})();
-```
-
-Until a project does that, treat "reload while the app route is open" as the
-thing to avoid, and park elsewhere first.
+One thing worth knowing but *not* the cause: `Spicetify.React` only appears
+~436ms into boot and `ReactDOM`/`Locale` ~967ms, so a custom app that touches
+them at module scope is genuinely fragile if it is ever evaluated that early.
+Adding a wait-for-globals gate to the app under test did not change the failure
+rate above, so treat that as separate hardening rather than a fix for this.
 
 `spicetify restart` is the heavier fallback — but it **quits Spotify without
 relaunching it**, so follow it with `open -a Spotify` and wait for the port.

--- a/.claude/skills/spicetify-drive/SKILL.md
+++ b/.claude/skills/spicetify-drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spicetify-drive
-description: Attach to the running Spotify desktop client over the Chrome DevTools Protocol to inspect or drive it — read Spicetify internals, run real GraphQL requests, measure computed styles and geometry, dispatch real key/mouse/wheel input, and take screenshots. Also covers the build → refresh → reload → attach loop for testing a Spicetify custom app or extension in the real client, including recovering the client when a reload wedges it. Use when a claim about Spotify's runtime needs verifying rather than guessing (does this GraphQL definition exist, what shape does it return, which element actually receives this click, does this scroll chain), or when the user asks to run, test, or screenshot a Spicetify app in Spotify.
+description: Attach to the running Spotify desktop client over the Chrome DevTools Protocol to inspect or drive it — read Spicetify internals, run real GraphQL requests, measure computed styles and geometry, dispatch real key/mouse/wheel input, and take screenshots. Also covers the build → refresh → reload → attach loop for testing a Spicetify custom app or extension in the real client, including recovering the app's route from Spotify's error boundary. Use when a claim about Spotify's runtime needs verifying rather than guessing (does this GraphQL definition exist, what shape does it return, which element actually receives this click, does this scroll chain), or when the user asks to run, test, or screenshot a Spicetify app in Spotify.
 ---
 
 # Driving Spotify over the debug port
@@ -67,8 +67,8 @@ spicetify refresh -a       # copies CustomApps into Spotify.app; PID unchanged
 ```
 
 Spotify keeps running throughout, so playback survives. The reload does blank the
-UI mid-use and can drop the client on the error screen, so say what you are doing
-rather than cycling this repeatedly while the user watches.
+UI mid-use and can leave the app's route on an error boundary, so say what you are
+doing rather than cycling this repeatedly while the user watches.
 
 **`-a` alone, never combined.** It copies both the app and its extension, because
 this project builds `extension.js` into the CustomApps folder. `-e` is for the
@@ -115,42 +115,57 @@ defaults read /Applications/Spotify.app/Contents/Info.plist CFBundleVersion
 that acts on it does not, so the port comes back with the re-apply rather than
 needing `enable-devtools` run again.
 
-## Reloading without wedging the client
+## Reloading, and Spotify's error boundary
 
-**Do not use `location.reload()`.** It regularly drops xpui into Spotify's
-"Something went wrong / Try reloading the page" screen. When that happens the
-whole client is down, not just the app under test: `window.<globalName>` is
-undefined, the main view is empty, and no app `<script>` is present. That reads
-exactly like the app crashing, and will send you debugging code that is fine.
+"Something went wrong / Try reloading the page" is **a route-level error boundary
+inside the main view, not a dead client.** The node lives under
+`MAIN` inside `.Root__main-view`; the library sidebar, top bar and player keep
+working, and `Spicetify.Platform` stays available throughout. So `Spicetify`
+being present proves nothing, and neither does the chrome looking fine.
 
-`Page.reload` over CDP does **not** rescue a client already on that screen. What
-does is clicking the dialog's own button. So always health-check after a reload,
-and recover, before measuring anything:
+Two consequences that cost real time:
+
+- **Scope the health check to the main view.** `document.body.innerText` cannot
+  tell a dead client from one bad route, because the body contains both the
+  boundary and the working chrome.
+- **The boundary latches, and reloading restores the last route.** If that route
+  is the one that failed, every reload lands straight back on it and re-latches.
+  That looks like the reload being broken when it is the route.
+
+Clicking the dialog's own `RELOAD PAGE` button is not a reliable escape: it only
+helps if whatever broke was transient. Measured on one stuck client, twelve
+clicks — six synthetic, six as real dispatched mouse events at the button's
+centre — recovered nothing. **Navigate somewhere known-good first, then reload:**
 
 ```js
-const reload = async (d) => {
+const reload = async (d, safeRoute = '/collection/tracks') => {
+  // Park somewhere that renders, so the reload does not restore the broken route.
+  await d.eval(`Spicetify.Platform.History.push({ pathname: ${JSON.stringify(safeRoute)} })`)
+    .catch(() => {});
+  await d.eval(`new Promise(r => setTimeout(r, 1500))`).catch(() => {});
+
   await d.send('Page.enable', {}).catch(() => {});
   await d.send('Page.reload', { ignoreCache: true });
+  await d.waitFor(`window.Spicetify && Spicetify.Platform ? 1 : 0`, { timeout: 40000 });
+  await d.eval(`new Promise(r => setTimeout(r, 3000))`).catch(() => {});
 
-  for (let i = 0; i < 6; i++) {
-    await d.waitFor(`document.readyState === 'complete' ? 1 : 0`, { timeout: 30000 }).catch(() => {});
-    const state = await d.eval(`(() => ({
-      error: document.body.innerText.includes('Something went wrong'),
-      ready: !!(window.Spicetify && Spicetify.Platform),
-    }))()`).catch(() => ({ error: true, ready: false }));
-    if (!state.error && state.ready) return;
-
-    await d.eval(`(() => { const b = [...document.querySelectorAll('button')]
-      .find(b => /reload page/i.test(b.textContent || '')); if (b) b.click(); })()`).catch(() => {});
-    await d.eval(`new Promise(r => setTimeout(r, 6000))`).catch(() => {});
-  }
-  throw new Error('client stuck on the error screen');
+  const broken = await d.eval(
+    `document.querySelector('.Root__main-view').innerText.includes('Something went wrong')`,
+  ).catch(() => true);
+  if (broken) throw new Error('main view still on the error boundary after reload');
 };
 ```
 
-Keep the loop. One run of this helper needed four passes and hit the error screen
-twice before coming back, so a single reload and a `sleep` is not equivalent.
-`spicetify restart` is the heavier fallback if it will not recover.
+Then navigate to the app route and confirm it mounted, rather than assuming.
+
+The trigger is not the reload API. `location.reload()` and CDP `Page.reload`
+both produce it; reloading a healthy client parked on a good route is fine and
+was done repeatedly without incident. Every occurrence followed a reload landing
+on the app's own route around a `pnpm build` + `spicetify refresh -a`, so treat a
+bundle swap as the risky moment and let the copy settle before reloading.
+
+`spicetify restart` is the heavier fallback — but it **quits Spotify without
+relaunching it**, so follow it with `open -a Spotify` and wait for the port.
 
 ## Side effects, and putting things back
 


### PR DESCRIPTION
## Summary

#221's reload section got the mechanism, the recovery and the culprit wrong. Driving the reveal work through the client contradicted all three, so this corrects them.

### It is not a dead client

"Something went wrong / Try reloading the page" is a **route-level error boundary**. Measured: the node sits under `MAIN` inside `.Root__main-view`, while the library sidebar, top bar and player keep working and `Spicetify.Platform` stays available throughout.

That matters because #221 claimed the whole client was down, and wrote the health check as `document.body.innerText.includes(...)` — a test that cannot separate a dead client from one bad route, since the body contains both the boundary and the working chrome. It now scopes to the main view.

It also means `Spicetify` being present proves nothing about health, which is exactly what made this hard to spot.

### Clicking the dialog is not the escape

#221 stated flatly that clicking `RELOAD PAGE` is what rescues it. On a stuck client that took **twelve clicks with no recovery** — six synthetic, then six as real dispatched mouse events at the button's centre after `el.click()` turned out to violate this skill's own rule about real events.

What works is parking on a route that renders and reloading from there. The boundary latches, and a reload restores the last route — so if that is the route that failed, every attempt lands straight back on it. That also re-explains #221's "needed four passes" note: not the loop grinding through flakiness, but the route failing until it happened not to.

### `location.reload()` is not the culprit

CDP `Page.reload` produces the same result, and reloading a healthy client parked on a good route was done repeatedly without incident. Every occurrence followed a reload landing on the app's own route around a `pnpm build` + `spicetify refresh -a`, so the bundle swap is the risky moment rather than the reload API.

### Also

`spicetify restart` quits Spotify **without relaunching it** — worth knowing before waiting on a port that will never answer.

## Testing

The rewritten helper was run verbatim against the live client: returns in 4.7s, lands on the safe route (which renders), and the app mounts cleanly afterwards with the main view healthy.

The 29-check harness from #221 still passes 29/29, so nothing else in the skill regressed.

## Note

The one thing not pinned down is the precise trigger inside the bundle swap. Reproducing it reliably means deliberately breaking the client repeatedly, which I did not want to do on a machine someone is using. The section says a bundle swap is the risky moment and to let the copy settle before reloading, which is accurate and actionable without overclaiming a cause I have not isolated.
