### PR TITLE
fix: review German reveal translations

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -8,11 +8,13 @@
     "guessBtn": "Raten",
     "skipBtn": "Überspringen +{{count}}s",
     "skipped": "Übersprungen",
-    "giveUp": "Aufgeben und auflösen",
+    "giveUp": "Aufgeben und Titel anzeigen",
     "nextSong": "Nächster Titel",
     "reveal": {
-      "wonIn": "In {{count}} erraten",
-      "gaveUpAfter": "Nach {{count}} aufgegeben",
+      "wonIn_one": "Mit {{count}} Versuch erraten",
+      "wonIn_other": "Mit {{count}} Versuchen erraten",
+      "gaveUpAfter_one": "Nach {{count}} Versuch aufgegeben",
+      "gaveUpAfter_other": "Nach {{count}} Versuchen aufgegeben",
       "playingInFull": "Wird vollständig abgespielt"
     },
     "menuEntry": "Spiele $t(appName)",


### PR DESCRIPTION
## Summary

Reviews and improves the German translations introduced for the song reveal UI.

- Clarifies the give-up action as “Aufgeben und Titel anzeigen”.
- Adds correct singular and plural forms for successful guesses.
- Adds correct singular and plural forms for giving up.

## Testing

- Confirmed `src/locales/de.json` is valid JSON.
- `pnpm run type-check` passes.
- `pnpm run lint` passes.
- `pnpm run build` completes successfully.
- `git diff --check` passes.

Part of #223